### PR TITLE
feat: add Goose harness support

### DIFF
--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -48,9 +48,9 @@ class EvalSettings(BaseSettings):
         default=Path("~/officeqa/officeqa.csv").expanduser(),
         description="Path to OfficeQA dataset CSV",
     )
-    sdk: Literal["claude", "opencode", "codex"] = Field(
+    sdk: Literal["claude", "opencode", "codex", "goose"] = Field(
         default="claude",
-        description="SDK to use: 'claude', 'opencode', or 'codex'",
+        description="SDK to use: 'claude', 'opencode', 'codex', or 'goose'",
     )
 
 

--- a/scripts/run_loop.py
+++ b/scripts/run_loop.py
@@ -84,9 +84,9 @@ class LoopSettings(BaseSettings):
     model: Optional[str] = Field(
         default=None, description="Model for base agent (opus, sonnet, haiku)"
     )
-    sdk: Literal["claude", "opencode", "codex"] = Field(
+    sdk: Literal["claude", "opencode", "codex", "goose"] = Field(
         default="claude",
-        description="SDK to use: 'claude', 'opencode', or 'codex'",
+        description="SDK to use: 'claude', 'opencode', 'codex', or 'goose'",
     )
 
 

--- a/src/cli/commands/init.py
+++ b/src/cli/commands/init.py
@@ -124,7 +124,7 @@ def init_cmd():
 
     harness = questionary.select(
         'Which harness?',
-        choices=['claude', 'opencode', 'codex'],
+        choices=['claude', 'opencode', 'codex', 'goose'],
         default=prompt_defaults['harness'],
     ).ask()
 

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -12,7 +12,7 @@ EVOSKILL_DIR = '.evoskill'
 
 @dataclass
 class HarnessConfig:
-    name: Literal['claude', 'opencode', 'codex'] = 'claude'
+    name: Literal['claude', 'opencode', 'codex', 'goose'] = 'claude'
     model: str | None = None
     data_dirs: list[str] = field(default_factory=list)
 

--- a/src/harness/__init__.py
+++ b/src/harness/__init__.py
@@ -12,11 +12,12 @@ Key exports:
 """
 
 from .agent import Agent, AgentTrace, OptionsProvider
-from .sdk_config import set_sdk, get_sdk, is_claude_sdk, is_opencode_sdk, is_codex_sdk
+from .sdk_config import set_sdk, get_sdk, is_claude_sdk, is_opencode_sdk, is_codex_sdk, is_goose_sdk
 from .utils import build_options, resolve_project_root, resolve_data_dirs
 from .claude.options import build_claudecode_options
 from .opencode.options import build_opencode_options
 from .codex.options import build_codex_options
+from .goose.options import build_goose_options
 
 __all__ = [
     "Agent",
@@ -27,10 +28,12 @@ __all__ = [
     "is_claude_sdk",
     "is_opencode_sdk",
     "is_codex_sdk",
+    "is_goose_sdk",
     "build_options",
     "build_claudecode_options",
     "build_opencode_options",
     "build_codex_options",
+    "build_goose_options",
     "resolve_project_root",
     "resolve_data_dirs",
 ]

--- a/src/harness/agent.py
+++ b/src/harness/agent.py
@@ -14,7 +14,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Type, TypeVar, Union
 from pydantic import BaseModel
-from .sdk_config import is_claude_sdk, is_codex_sdk
+from .sdk_config import is_claude_sdk, is_codex_sdk, is_goose_sdk
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +156,9 @@ class Agent(Generic[T]):
         elif is_codex_sdk():
             from .codex import executor as _codex_executor
             return await _codex_executor.execute_query(options, query)
+        elif is_goose_sdk():
+            from .goose import executor as _goose_executor
+            return await _goose_executor.execute_query(options, query)
         else:
             from .opencode import executor as _opencode_executor
             return await _opencode_executor.execute_query(options, query)
@@ -212,6 +215,9 @@ class Agent(Generic[T]):
         elif is_codex_sdk():
             from .codex import executor as _codex_executor
             fields = _codex_executor.parse_response(messages, self.response_model, self._get_options)
+        elif is_goose_sdk():
+            from .goose import executor as _goose_executor
+            fields = _goose_executor.parse_response(messages, self.response_model, self._get_options)
         else:
             from .opencode import executor as _opencode_executor
             fields = _opencode_executor.parse_response(messages, self.response_model, self._get_options,)

--- a/src/harness/goose/__init__.py
+++ b/src/harness/goose/__init__.py
@@ -1,0 +1,6 @@
+"""Goose subprocess harness — option building and execution."""
+
+from .options import build_goose_options, split_goose_model
+from .executor import execute_query, parse_response
+
+__all__ = ["build_goose_options", "split_goose_model", "execute_query", "parse_response"]

--- a/src/harness/goose/executor.py
+++ b/src/harness/goose/executor.py
@@ -1,0 +1,264 @@
+"""Goose harness execution and response parsing.
+
+This module handles all Goose-specific logic:
+    - Building a recipe YAML and invoking the Goose CLI as a subprocess
+    - Parsing stdout into AgentTrace fields
+
+How Goose differs from Claude, OpenCode, and Codex:
+
+    Claude SDK:
+        - Spawns a Claude Code process per query
+        - Returns [SystemMessage, ..., ResultMessage]
+        - Structured output in ResultMessage.structured_output
+
+    OpenCode SDK:
+        - Manages a persistent HTTP server
+        - Returns AssistantMessage with info/parts as extra fields
+        - Structured output in info["structured_output"]
+
+    Codex SDK:
+        - Creates a thread, runs prompts within it
+        - Returns a turn object with .final_response (JSON string)
+
+    Goose (subprocess):
+        - No Python SDK — invoked as `goose run --recipe <yaml> --output-format json`
+        - Query is embedded in the recipe YAML's "prompt" field (--recipe and --text can't be combined)
+        - Returns a SimpleNamespace with .stdout, .stderr, .returncode
+        - Structured JSON output is the LAST non-empty line of stdout
+        - No cost/session/uuid info available (all set to zero/"unknown")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import tempfile
+from types import SimpleNamespace
+from typing import Any, Callable, Type
+
+import yaml
+from pydantic import BaseModel, ValidationError
+
+
+async def execute_query(options: dict[str, Any], query: str) -> list[Any]:
+    """Execute a query by invoking the Goose CLI as an async subprocess.
+
+    Writes a temporary recipe YAML file containing the system prompt and
+    output schema, then runs `goose run --recipe <path> -t <query>`.
+    The recipe file is cleaned up in a finally block even if execution fails.
+
+    The Goose CLI is imported lazily (checked via shutil.which) so the module
+    can be loaded even when goose is not installed. Only fails when you
+    actually try to use the Goose harness.
+
+    Args:
+        options: Dict built by build_goose_options() with keys:
+            - system: system prompt text
+            - output_schema: JSON schema dict for structured output
+            - provider: provider name (e.g., "anthropic")
+            - model: model name (e.g., "claude-sonnet-4-6")
+            - working_directory: path where the agent operates
+            - tools: tool names (metadata only, not sent to CLI)
+            - data_dirs: extra data directory paths
+        query: The question/task to send to the agent
+
+    Returns:
+        Single-item list containing a SimpleNamespace with .stdout, .stderr,
+        and .returncode. Wrapped in a list for consistency with other executors.
+
+    Raises:
+        RuntimeError: If the goose CLI is not found on PATH.
+    """
+    if not shutil.which("goose"):
+        raise RuntimeError(
+            "Goose CLI not found. Install with: brew install block-goose-cli"
+        )
+
+    # Build the recipe YAML structure.
+    # NOTE: --recipe and --text/-t CANNOT be combined in Goose CLI.
+    # The query is embedded in the recipe's "prompt" field instead.
+    recipe: dict[str, Any] = {
+        "version": 1,
+        "title": "EvoSkill Agent Query",
+        "description": "Auto-generated recipe for EvoSkill agent execution",
+        "instructions": options.get("system", ""),
+        "prompt": query,
+        "response": {
+            "json_schema": options.get("output_schema", {}),
+        },
+    }
+
+    # Write recipe to a temp file — cleaned up in finally regardless of errors
+    fd, recipe_path = tempfile.mkstemp(suffix=".yaml", prefix="goose_recipe_")
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml.safe_dump(recipe, f)
+
+        # Build environment with provider/model overrides.
+        # We copy os.environ so we never mutate the global process environment.
+        env = dict(os.environ)
+        if options.get("provider"):
+            env["GOOSE_PROVIDER"] = options["provider"]
+        if options.get("model"):
+            env["GOOSE_MODEL"] = options["model"]
+
+        # Run goose as an async subprocess so we don't block the event loop.
+        # No -t/--text flag — the query is in the recipe's "prompt" field.
+        proc = await asyncio.create_subprocess_exec(
+            "goose",
+            "run",
+            "--recipe", recipe_path,
+            "--output-format", "json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=options.get("working_directory", "."),
+            env=env,
+        )
+        stdout_bytes, stderr_bytes = await proc.communicate()
+
+        return [SimpleNamespace(
+            stdout=stdout_bytes.decode("utf-8", errors="replace"),
+            stderr=stderr_bytes.decode("utf-8", errors="replace"),
+            returncode=proc.returncode,
+        )]
+    finally:
+        # Always remove the temp recipe file, even if execution raised
+        try:
+            os.unlink(recipe_path)
+        except OSError:
+            pass
+
+
+def parse_response(
+    messages: list[Any],
+    response_model: Type[BaseModel],
+    get_options: Callable[[], Any],
+) -> dict[str, Any]:
+    """Parse a Goose subprocess result into AgentTrace field values.
+
+    Goose writes structured JSON output as the last non-empty line of stdout.
+    All preceding lines are treated as informational log output and are ignored.
+
+    When a non-zero return code is detected, the stderr is captured as the
+    parse_error rather than attempting to parse stdout.
+
+    Args:
+        messages: Single-item list containing a SimpleNamespace result
+                  (from execute_query) with .stdout, .stderr, .returncode.
+        response_model: Pydantic model to validate the parsed JSON against
+                       (e.g., AgentResponse, SkillProposerResponse)
+        get_options: Callable that returns the options dict (for model/tools/provider
+                    metadata). Same pattern as Codex and OpenCode executors.
+
+    Returns:
+        Dict of field values ready to unpack into AgentTrace(**fields).
+    """
+    result = messages[0]
+
+    output = None
+    parse_error = None
+    raw_structured_output = None
+    result_text = getattr(result, "stdout", "") or ""
+
+    # Check for subprocess failure first — non-zero exit is always an error
+    if getattr(result, "returncode", 0) != 0:
+        stderr = getattr(result, "stderr", "")
+        parse_error = f"Goose exited with code {result.returncode}: {stderr[:500]}"
+    else:
+        # Goose --output-format json returns log lines at the top, then a big
+        # JSON object containing the full conversation with messages array.
+        # The structured output is in the recipe__final_output tool call arguments.
+        #
+        # Strategy:
+        #   1. Find the JSON blob in stdout (skip leading log lines)
+        #   2. Parse it and look for recipe__final_output tool call
+        #   3. Extract the arguments dict — that's our structured output
+        #   4. Fallback: try the last assistant message's text content
+
+        # Find where the JSON starts (first "{" on a line)
+        json_start = -1
+        for i, char in enumerate(result_text):
+            if char == "{":
+                json_start = i
+                break
+
+        if json_start == -1:
+            parse_error = "No JSON found in Goose output"
+        else:
+            try:
+                conversation = json.loads(result_text[json_start:])
+            except json.JSONDecodeError as e:
+                parse_error = f"JSONDecodeError parsing Goose output: {e}"
+                conversation = None
+
+            if conversation and isinstance(conversation, dict):
+                messages_list = conversation.get("messages", [])
+
+                # Strategy 1: Find recipe__final_output tool call
+                for msg in messages_list:
+                    if msg.get("role") != "assistant":
+                        continue
+                    for content in msg.get("content", []):
+                        if content.get("type") == "toolRequest":
+                            tool_call = content.get("toolCall", {}).get("value", {})
+                            if tool_call.get("name") == "recipe__final_output":
+                                raw_structured_output = tool_call.get("arguments", {})
+                                break
+                    if raw_structured_output:
+                        break
+
+                # Strategy 2: Fallback — try last assistant text content as JSON
+                if raw_structured_output is None:
+                    for msg in reversed(messages_list):
+                        if msg.get("role") != "assistant":
+                            continue
+                        for content in msg.get("content", []):
+                            if content.get("type") == "text":
+                                try:
+                                    raw_structured_output = json.loads(content["text"])
+                                except (json.JSONDecodeError, KeyError):
+                                    pass
+                        if raw_structured_output:
+                            break
+
+                # Validate against the Pydantic model
+                if raw_structured_output is not None:
+                    try:
+                        output = response_model.model_validate(raw_structured_output)
+                    except (ValidationError, TypeError) as e:
+                        parse_error = f"{type(e).__name__}: {str(e)}"
+                elif not parse_error:
+                    parse_error = "No structured output found in Goose conversation"
+
+    # Get model name, provider, and tools from the options we sent.
+    # Goose doesn't return these in the response, so we read from our config.
+    options = get_options()
+    model_name = options.get("model", "unknown") if isinstance(options, dict) else "unknown"
+    tools = options.get("tools", []) if isinstance(options, dict) else []
+
+    # Build the AgentTrace fields dict.
+    # Limitations vs other harnesses:
+    #   - uuid="unknown": Goose CLI doesn't expose a session UUID
+    #   - session_id="unknown": no persistent session tracking
+    #   - duration_ms=0: not reported by Goose CLI
+    #   - total_cost_usd=0.0: not exposed by Goose CLI
+    #   - num_turns=1: Goose runs as a single invocation
+    #   - usage={}: token counts not exposed by Goose CLI
+    return dict(
+        uuid="unknown",
+        session_id="unknown",
+        model=model_name,
+        tools=tools,
+        duration_ms=0,
+        total_cost_usd=0.0,
+        num_turns=1,
+        usage={},
+        result=result_text,
+        is_error=parse_error is not None,
+        output=output,
+        parse_error=parse_error,
+        raw_structured_output=raw_structured_output,
+        messages=messages,
+    )

--- a/src/harness/goose/options.py
+++ b/src/harness/goose/options.py
@@ -1,0 +1,120 @@
+"""Goose SDK option building.
+
+All Goose-specific construction logic lives here.
+
+Key differences from Claude, OpenCode, and Codex:
+    - Goose is subprocess-based — no Python SDK to import
+    - Model is specified as 'provider/model' (e.g., 'anthropic/claude-sonnet-4-6')
+      and split into separate GOOSE_PROVIDER and GOOSE_MODEL env vars
+    - A recipe YAML is written to a temp file and passed to goose CLI at runtime
+    - Tools are stored as metadata only — Goose has its own built-in toolset
+    - No persistent server to manage (unlike OpenCode)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from ..utils import resolve_project_root, resolve_data_dirs
+
+
+# Default model and provider when none is specified.
+DEFAULT_GOOSE_MODEL = "claude-sonnet-4-6"
+DEFAULT_GOOSE_PROVIDER = "anthropic"
+
+
+def split_goose_model(model: str | None) -> tuple[str, str]:
+    """Split 'provider/model' string or return defaults.
+
+    Examples:
+        split_goose_model(None)                    → ("anthropic", "claude-sonnet-4-6")
+        split_goose_model("openrouter/gpt-5")      → ("openrouter", "gpt-5")
+        split_goose_model("claude-sonnet-4-6")     → ("anthropic", "claude-sonnet-4-6")
+
+    Args:
+        model: Model string, optionally prefixed with 'provider/'.
+
+    Returns:
+        (provider, model_name) tuple.
+    """
+    if model is None:
+        return DEFAULT_GOOSE_PROVIDER, DEFAULT_GOOSE_MODEL
+    if "/" in model:
+        provider, model_name = model.split("/", 1)
+        return provider, model_name
+    return DEFAULT_GOOSE_PROVIDER, model
+
+
+def build_goose_options(
+    *,
+    system: str,
+    schema: dict[str, Any],
+    tools: Iterable[str],
+    project_root: str | Path | None = None,
+    model: str | None = None,
+    data_dirs: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Build an options dict for the Goose harness.
+
+    This function has the same signature as build_claudecode_options(),
+    build_opencode_options(), and build_codex_options() — it is called by
+    build_options() in utils.py when the active SDK is "goose". Agent
+    profile factories never call this directly; they all go through
+    build_options().
+
+    Args:
+        system: System prompt text (from the agent profile's prompt.txt or task.md)
+        schema: JSON schema dict for structured output (from Pydantic model_json_schema())
+        tools: Tool names from the agent profile (e.g., ["Read", "Write", "Bash"]).
+               Stored as metadata only — Goose has its own built-in tools.
+        project_root: Path to the project root. Resolved automatically if None.
+        model: Model string, optionally prefixed with 'provider/'.
+               Defaults to 'anthropic/claude-sonnet-4-6' if None.
+        data_dirs: Extra data directories the agent should have access to.
+                   If provided, their paths are appended to the system prompt
+                   so the agent knows where to look.
+
+    Returns:
+        Dict with keys: system, output_schema, provider, model, working_directory,
+        tools, data_dirs. This dict is passed to execute_query() in executor.py.
+    """
+    root = resolve_project_root(project_root)
+    resolved_data_dirs = resolve_data_dirs(root, data_dirs)
+    provider, model_name = split_goose_model(model)
+
+    # If data directories are provided, append them to the system prompt
+    # so the agent knows it can read files from those paths.
+    # Same pattern as Codex (see codex/options.py).
+    system_with_dirs = system
+    if resolved_data_dirs:
+        dirs_note = "\n".join(f"- {path}" for path in resolved_data_dirs)
+        system_with_dirs = (
+            f"{system.rstrip()}\n\n"
+            "Additional data directories:\n"
+            f"{dirs_note}"
+        )
+
+    return {
+        # The system prompt — written into the Goose recipe YAML
+        "system": system_with_dirs,
+
+        # JSON schema for structured output — embedded in the recipe's response block.
+        "output_schema": schema,
+
+        # Provider name — set as GOOSE_PROVIDER env var when invoking the CLI
+        "provider": provider,
+
+        # Model name — set as GOOSE_MODEL env var when invoking the CLI
+        "model": model_name,
+
+        # Working directory — the Goose CLI subprocess runs in this directory
+        "working_directory": str(root),
+
+        # Tool names from the agent profile — stored as metadata for AgentTrace.
+        # Goose has its own built-in tools; these are NOT sent to the CLI.
+        "tools": list(tools),
+
+        # Resolved absolute paths to extra data directories
+        "data_dirs": resolved_data_dirs,
+    }

--- a/src/harness/sdk_config.py
+++ b/src/harness/sdk_config.py
@@ -5,17 +5,21 @@ This module provides a global setting to choose between claude-agent-sdk and ope
 
 from typing import Literal
 
-SDKType = Literal["claude", "opencode", "codex"]
+SDKType = Literal["claude", "opencode", "codex", "goose"]
 
 # Global SDK selection (can be overridden via CLI arguments)
 _current_sdk: SDKType = "claude"
+
+_VALID_SDKS = ("claude", "opencode", "codex", "goose")
 
 
 def set_sdk(sdk: SDKType) -> None:
     """Set the current SDK to use globally."""
     global _current_sdk
-    if sdk not in ("claude", "opencode", "codex"):
-        raise ValueError(f"Invalid SDK type: {sdk}. Must be 'claude', 'opencode', or 'codex'")
+    if sdk not in _VALID_SDKS:
+        raise ValueError(
+            f"Invalid SDK type: {sdk}. Must be one of: {', '.join(repr(s) for s in _VALID_SDKS)}"
+        )
     _current_sdk = sdk
 
 
@@ -37,3 +41,8 @@ def is_opencode_sdk() -> bool:
 def is_codex_sdk() -> bool:
     """Check if codex is the current SDK."""
     return _current_sdk == "codex"
+
+
+def is_goose_sdk() -> bool:
+    """Check if goose is the current SDK."""
+    return _current_sdk == "goose"

--- a/src/harness/utils.py
+++ b/src/harness/utils.py
@@ -101,4 +101,14 @@ def build_options(
             model=model,
             data_dirs=data_dirs,
         )
+    if sdk == "goose":
+        from .goose.options import build_goose_options
+        return build_goose_options(
+            system=system,
+            schema=schema,
+            tools=tools,
+            project_root=project_root,
+            model=model,
+            data_dirs=data_dirs,
+        )
     raise ValueError(f"Unknown SDK: {sdk!r}")

--- a/src/registry/sdk_utils.py
+++ b/src/registry/sdk_utils.py
@@ -55,6 +55,21 @@ def config_to_options(
             "data_dirs": add_dirs or [],
         }
 
+    if config.metadata.get("sdk") == "goose":
+        system_prompt = config.system_prompt
+        system_text = system_prompt.get("content") or system_prompt.get("append", "")
+        provider = config.metadata.get("provider", "anthropic")
+        model = config.metadata.get("model", "claude-sonnet-4-6")
+        return {
+            "system": system_text,
+            "output_schema": config.output_format.get("schema") if config.output_format else {},
+            "provider": provider,
+            "model": model,
+            "working_directory": cwd,
+            "tools": config.allowed_tools,
+            "data_dirs": add_dirs or [],
+        }
+
     return ClaudeAgentOptions(
         system_prompt=config.system_prompt,
         allowed_tools=config.allowed_tools,
@@ -105,12 +120,35 @@ def options_to_config(
             else {"type": "text", "content": system_text}
         )
 
-        # Detect SDK type: codex options have output_schema + working_directory
-        # while opencode options have format + cwd
-        if "output_schema" in options and "working_directory" in options:
+        # Detect SDK type:
+        #   - goose options have output_schema + working_directory + provider
+        #   - codex options have output_schema + working_directory (no provider)
+        #   - opencode options have format + cwd
+        if "output_schema" in options and "working_directory" in options and "provider" in options:
+            sdk_type = "goose"
+        elif "output_schema" in options and "working_directory" in options:
             sdk_type = "codex"
         else:
             sdk_type = "opencode"
+
+        if sdk_type == "goose":
+            base_metadata.update(
+                {
+                    "sdk": "goose",
+                    "provider": options.get("provider", "anthropic"),
+                    "model": options.get("model", "claude-sonnet-4-6"),
+                    "working_directory": options.get("working_directory"),
+                }
+            )
+            return ProgramConfig(
+                name=name,
+                parent=parent,
+                generation=generation,
+                system_prompt=system_prompt,
+                allowed_tools=allowed_tools,
+                output_format={"schema": options.get("output_schema", {})},
+                metadata=base_metadata,
+            )
 
         if sdk_type == "codex":
             base_metadata.update(

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -614,7 +614,7 @@ class TestSdkConfigCodex:
 
     def test_invalid_sdk_still_raises(self):
         with pytest.raises(ValueError, match="Invalid SDK"):
-            set_sdk("goose")  # type: ignore[arg-type]
+            set_sdk("unknown_harness")  # type: ignore[arg-type]
 
 
 # ===========================================================================
@@ -824,3 +824,349 @@ class TestCodexParseResponse:
 
         assert fields["output"] is None
         assert "ValidationError" in fields["parse_error"]
+
+
+# ===========================================================================
+# TestSdkConfigGoose — goose SDK toggle and is_goose_sdk() helper
+# ===========================================================================
+
+class TestSdkConfigGoose:
+    """Test goose SDK toggle and is_goose_sdk() helper."""
+
+    def setup_method(self):
+        set_sdk("claude")
+
+    def teardown_method(self):
+        set_sdk("claude")
+
+    def test_set_sdk_to_goose(self):
+        from src.harness.sdk_config import is_goose_sdk
+        set_sdk("goose")
+        assert get_sdk() == "goose"
+        assert is_goose_sdk() is True
+        assert is_claude_sdk() is False
+        assert is_opencode_sdk() is False
+
+    def test_is_goose_sdk_false_by_default(self):
+        from src.harness.sdk_config import is_goose_sdk
+        assert is_goose_sdk() is False
+
+    def test_set_sdk_goose_then_back_to_claude(self):
+        from src.harness.sdk_config import is_goose_sdk
+        set_sdk("goose")
+        set_sdk("claude")
+        assert is_claude_sdk() is True
+        assert is_goose_sdk() is False
+
+    def test_invalid_sdk_still_raises(self):
+        with pytest.raises(ValueError, match="Invalid SDK"):
+            set_sdk("notreal")  # type: ignore[arg-type]
+
+
+# ===========================================================================
+# TestGooseOptions — build_goose_options()
+# ===========================================================================
+
+class TestGooseSplitModel:
+    """Test split_goose_model() directly for all branches."""
+
+    def test_none_returns_defaults(self):
+        from src.harness.goose.options import split_goose_model, DEFAULT_GOOSE_PROVIDER, DEFAULT_GOOSE_MODEL
+
+        provider, model = split_goose_model(None)
+        assert provider == DEFAULT_GOOSE_PROVIDER
+        assert model == DEFAULT_GOOSE_MODEL
+
+    def test_with_slash_splits_on_first_slash(self):
+        from src.harness.goose.options import split_goose_model
+
+        provider, model = split_goose_model("openrouter/gpt-4-turbo")
+        assert provider == "openrouter"
+        assert model == "gpt-4-turbo"
+
+    def test_without_slash_uses_default_provider(self):
+        from src.harness.goose.options import split_goose_model, DEFAULT_GOOSE_PROVIDER
+
+        provider, model = split_goose_model("claude-sonnet-4-6")
+        assert provider == DEFAULT_GOOSE_PROVIDER
+        assert model == "claude-sonnet-4-6"
+
+    def test_multiple_slashes_splits_only_on_first(self):
+        from src.harness.goose.options import split_goose_model
+
+        provider, model = split_goose_model("some-provider/model/version")
+        assert provider == "some-provider"
+        assert model == "model/version"
+
+
+class TestGooseExecuteQueryErrors:
+    """Test execute_query error path when goose CLI is not installed."""
+
+    def test_raises_runtime_error_when_goose_not_found(self):
+        import asyncio
+        from unittest.mock import patch
+        from src.harness.goose.executor import execute_query
+
+        async def run():
+            with patch("shutil.which", return_value=None):
+                await execute_query({"system": "test", "output_schema": {}}, "query")
+
+        with pytest.raises(RuntimeError, match="Goose CLI not found"):
+            asyncio.run(run())
+
+
+class TestGooseOptions:
+    """Test the Goose options builder — pure dict construction, no subprocess calls."""
+
+    def test_basic_structure(self, tmp_path):
+        from src.harness.goose.options import build_goose_options
+
+        result = build_goose_options(
+            system="You are helpful.",
+            schema={"type": "object"},
+            tools=["Read", "Bash"],
+            project_root=tmp_path,
+            model="anthropic/claude-sonnet-4-6",
+        )
+
+        assert result["system"] == "You are helpful."
+        assert result["output_schema"] == {"type": "object"}
+        assert result["provider"] == "anthropic"
+        assert result["model"] == "claude-sonnet-4-6"
+        assert result["working_directory"] == str(tmp_path.resolve())
+        assert "Read" in result["tools"]
+        assert "Bash" in result["tools"]
+
+    def test_default_model_and_provider_when_none(self, tmp_path):
+        from src.harness.goose.options import (
+            build_goose_options,
+            DEFAULT_GOOSE_MODEL,
+            DEFAULT_GOOSE_PROVIDER,
+        )
+
+        result = build_goose_options(
+            system="prompt",
+            schema={},
+            tools=[],
+            project_root=tmp_path,
+            model=None,
+        )
+
+        assert result["model"] == DEFAULT_GOOSE_MODEL
+        assert result["provider"] == DEFAULT_GOOSE_PROVIDER
+
+    def test_model_with_slash_splits(self, tmp_path):
+        from src.harness.goose.options import build_goose_options
+
+        result = build_goose_options(
+            system="s",
+            schema={},
+            tools=[],
+            project_root=tmp_path,
+            model="openrouter/gpt-5",
+        )
+
+        assert result["provider"] == "openrouter"
+        assert result["model"] == "gpt-5"
+
+    def test_data_dirs_appended_to_system(self, tmp_path):
+        from src.harness.goose.options import build_goose_options
+
+        data_dir = tmp_path / "extra_data"
+        data_dir.mkdir()
+
+        result = build_goose_options(
+            system="base system",
+            schema={},
+            tools=[],
+            project_root=tmp_path,
+            data_dirs=[str(data_dir)],
+        )
+
+        assert str(data_dir) in result["system"]
+        assert "Additional data directories" in result["system"]
+        assert str(data_dir) in result["data_dirs"]
+
+    def test_tools_stored_as_list(self, tmp_path):
+        from src.harness.goose.options import build_goose_options
+
+        result = build_goose_options(
+            system="s",
+            schema={},
+            tools=["Read", "Write", "Bash"],
+            project_root=tmp_path,
+        )
+
+        assert isinstance(result["tools"], list)
+        assert set(result["tools"]) == {"Read", "Write", "Bash"}
+
+    def test_no_data_dirs_system_unchanged(self, tmp_path):
+        from src.harness.goose.options import build_goose_options
+
+        result = build_goose_options(
+            system="clean prompt",
+            schema={},
+            tools=[],
+            project_root=tmp_path,
+            data_dirs=None,
+        )
+
+        assert result["system"] == "clean prompt"
+        assert result["data_dirs"] == []
+
+
+# ===========================================================================
+# TestGooseParseResponse — parse_response()
+# ===========================================================================
+
+import types as _types
+
+
+def _make_goose_result(stdout="", stderr="", returncode=0):
+    return _types.SimpleNamespace(
+        stdout=stdout,
+        stderr=stderr,
+        returncode=returncode,
+    )
+
+
+def _make_goose_conversation_stdout(structured_output: dict) -> str:
+    """Build a fake Goose --output-format json stdout with the conversation JSON."""
+    conversation = {
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "query"}]},
+            {"role": "assistant", "content": [
+                {"type": "toolRequest", "id": "tool1", "toolCall": {
+                    "status": "success",
+                    "value": {
+                        "name": "recipe__final_output",
+                        "arguments": structured_output,
+                    }
+                }}
+            ]},
+            {"role": "user", "content": [{"type": "toolResponse", "id": "tool1", "toolResult": {"status": "success"}}]},
+            {"role": "assistant", "content": [
+                {"type": "text", "text": _json.dumps(structured_output)}
+            ]},
+        ]
+    }
+    return f"starting session | provider: anthropic model: test\n{_json.dumps(conversation)}"
+
+
+def _make_goose_get_options(provider="anthropic", model="claude-sonnet-4-6", tools=None):
+    return lambda: {
+        "provider": provider,
+        "model": model,
+        "tools": tools or ["Read", "Bash"],
+        "working_directory": "/tmp",
+        "output_schema": {},
+    }
+
+
+class TestGooseParseResponse:
+    """Test parse_response for the Goose harness."""
+
+    def test_parses_structured_output_from_conversation(self):
+        from src.harness.goose.executor import parse_response as goose_parse
+
+        stdout = _make_goose_conversation_stdout({"final_answer": "4", "reasoning": "math"})
+        result = _make_goose_result(stdout=stdout)
+        fields = goose_parse([result], AgentResponse, _make_goose_get_options())
+
+        assert fields["output"] is not None
+        assert fields["output"].final_answer == "4"
+        assert fields["parse_error"] is None
+        assert fields["is_error"] is False
+
+    def test_handles_no_json_in_stdout(self):
+        from src.harness.goose.executor import parse_response as goose_parse
+
+        result = _make_goose_result(stdout="not JSON at all, no braces anywhere")
+        fields = goose_parse([result], AgentResponse, _make_goose_get_options())
+
+        assert fields["output"] is None
+        assert fields["parse_error"] is not None
+        assert fields["is_error"] is True
+
+    def test_handles_empty_stdout(self):
+        from src.harness.goose.executor import parse_response as goose_parse
+
+        result = _make_goose_result(stdout="")
+        fields = goose_parse([result], AgentResponse, _make_goose_get_options())
+
+        assert fields["output"] is None
+        assert fields["parse_error"] is not None
+        assert fields["is_error"] is True
+
+    def test_handles_nonzero_returncode(self):
+        from src.harness.goose.executor import parse_response as goose_parse
+
+        result = _make_goose_result(stdout="some output", stderr="critical error occurred", returncode=1)
+        fields = goose_parse([result], AgentResponse, _make_goose_get_options())
+
+        assert fields["is_error"] is True
+        assert "critical error occurred" in fields["parse_error"]
+
+    def test_model_comes_from_options(self):
+        from src.harness.goose.executor import parse_response as goose_parse
+
+        stdout = _make_goose_conversation_stdout({"final_answer": "x", "reasoning": "y"})
+        result = _make_goose_result(stdout=stdout)
+        fields = goose_parse([result], AgentResponse, _make_goose_get_options(model="my-model"))
+
+        assert fields["model"] == "my-model"
+
+    def test_provider_comes_from_options(self):
+        from src.harness.goose.executor import parse_response as goose_parse
+
+        stdout = _make_goose_conversation_stdout({"final_answer": "x", "reasoning": "y"})
+        result = _make_goose_result(stdout=stdout)
+        opts_fn = _make_goose_get_options(provider="openrouter")
+        fields = goose_parse([result], AgentResponse, opts_fn)
+
+        # provider is stored in the options dict, verify it's accessible
+        assert opts_fn()["provider"] == "openrouter"
+        # output should still parse fine
+        assert fields["output"] is not None
+
+    def test_cost_is_always_zero(self):
+        from src.harness.goose.executor import parse_response as goose_parse
+
+        result = _make_goose_result(stdout="")
+        fields = goose_parse([result], AgentResponse, _make_goose_get_options())
+
+        assert fields["total_cost_usd"] == 0.0
+
+    def test_uuid_and_session_id_are_unknown(self):
+        from src.harness.goose.executor import parse_response as goose_parse
+
+        stdout = _make_goose_conversation_stdout({"final_answer": "a", "reasoning": "b"})
+        result = _make_goose_result(stdout=stdout)
+        fields = goose_parse([result], AgentResponse, _make_goose_get_options())
+
+        assert fields["uuid"] == "unknown"
+        assert fields["session_id"] == "unknown"
+
+    def test_json_validation_error_recorded(self):
+        from src.harness.goose.executor import parse_response as goose_parse
+
+        # Valid conversation JSON but tool call has wrong schema fields
+        stdout = _make_goose_conversation_stdout({"wrong_field": "value"})
+        result = _make_goose_result(stdout=stdout)
+        fields = goose_parse([result], AgentResponse, _make_goose_get_options())
+
+        assert fields["output"] is None
+        assert fields["parse_error"] is not None
+        assert fields["is_error"] is True
+
+    def test_extracts_from_tool_call_arguments(self):
+        from src.harness.goose.executor import parse_response as goose_parse
+
+        stdout = _make_goose_conversation_stdout({"final_answer": "7", "reasoning": "logic"})
+        result = _make_goose_result(stdout=stdout)
+        fields = goose_parse([result], AgentResponse, _make_goose_get_options())
+
+        assert fields["output"] is not None
+        assert fields["output"].final_answer == "7"
+        assert fields["parse_error"] is None
+        assert fields["raw_structured_output"] == {"final_answer": "7", "reasoning": "logic"}


### PR DESCRIPTION
Add Goose as a fourth harness alongside Claude Code, OpenCode, and Codex. Goose is integrated via subprocess (no Python SDK) — the executor writes a temporary recipe YAML with the system prompt and JSON schema, runs `goose run --recipe <path> --output-format json`, then extracts the structured output from the recipe__final_output tool call in the conversation JSON.

New files:
- src/harness/goose/__init__.py, options.py, executor.py

Modified files:
- sdk_config.py: "goose" in SDKType, is_goose_sdk()
- utils.py: goose branch in build_options() router
- agent.py: goose dispatch in _execute_query() and run()
- __init__.py: export is_goose_sdk, build_goose_options
- cli/config.py, cli/commands/init.py: "goose" in choices
- registry/sdk_utils.py: goose branches in conversions
- scripts/run_loop.py, run_eval.py: "goose" in SDK Literal

Key design decisions:
- Subprocess-based (goose run), no Python SDK dependency
- Temp recipe YAML with title, description, instructions, prompt, response.json_schema
- Structured output extracted from recipe__final_output tool call arguments
- Fallback: parse last assistant text content as JSON
- Provider/model via env vars (GOOSE_PROVIDER, GOOSE_MODEL)
- Temp file cleanup in finally block

Tests: 25 new (sdk_config, options, split_model, parse_response, execute errors)
Total: 404 passing, zero changes to agent_profiles/