### PR TITLE
Feat/openhands integration

### DIFF
--- a/docs/openhands_integration_requirements.md
+++ b/docs/openhands_integration_requirements.md
@@ -1,0 +1,51 @@
+# OpenHands Requirement For EvoSkill
+
+For EvoSkill, the main remaining OpenHands requirement is native final structured output.
+
+## Why EvoSkill Needs This
+
+EvoSkill does not just need event logs. It needs one final payload that can be parsed and validated against a schema.
+
+Examples:
+
+- `AgentResponse`
+- `SkillProposerResponse`
+- `ToolGeneratorResponse`
+- `PromptProposerResponse`
+- `PromptGeneratorResponse`
+
+## What Event JSON Solves
+
+OpenHands event JSON is useful for:
+
+- tracing the run
+- logging tool calls
+- debugging failures
+- persisting execution history
+
+But event JSON is not the same as a guaranteed final schema-valid result.
+
+## What EvoSkill Actually Needs
+
+One of these needs to be true:
+
+- the SDK or headless mode can accept a JSON schema and return a validated final payload
+- or OpenHands has an officially supported strict-final-JSON contract that is reliable enough for automated parsing and validation
+
+The final output should be suitable for:
+
+- `json.loads(...)`
+- `response_model.model_validate(...)`
+
+## Questions For OpenHands
+
+1. Can a run be constrained to an exact final JSON schema?
+2. If yes, where is that final structured payload returned in SDK and headless mode?
+3. If the model violates the schema, what is the failure behavior?
+4. If native schema enforcement does not exist, what is the recommended strict-JSON pattern for automated systems like EvoSkill?
+
+## Bottom Line
+
+If OpenHands can guarantee final schema-valid output, EvoSkill integration becomes straightforward.
+
+If not, EvoSkill would need a prompt-based JSON extraction layer, which is more brittle for proposer and generator flows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ requires-python = ">=3.12"
 dependencies = [
     "opencode-ai>=0.0.26",
     "claude-agent-sdk>=0.1.16",
+    "openhands-sdk>=1.16.1",
+    "openhands-tools>=1.16.1",
     "click>=8.1.8",
     "dspy>=3.0.4",
     "ipykernel>=7.1.0",

--- a/src/agent_profiles/__init__.py
+++ b/src/agent_profiles/__init__.py
@@ -4,6 +4,8 @@ Each subdirectory defines a specific agent role (system prompt, tools, schema).
 Harness/SDK logic lives in src.harness, not here.
 """
 
+from src.harness.agent import Agent
+
 from .proposer import proposer_options
 from .skill_generator import skill_generator_options
 from .base_agent import base_agent_options, make_base_agent_options
@@ -18,6 +20,7 @@ from .skill_proposer import skill_proposer_options
 from .prompt_proposer import prompt_proposer_options
 
 __all__ = [
+    "Agent",
     "proposer_options",
     "skill_generator_options",
     "base_agent_options",

--- a/src/agent_profiles/base.py
+++ b/src/agent_profiles/base.py
@@ -1,0 +1,5 @@
+"""Compatibility exports for older tests and call sites."""
+
+from src.harness.agent import Agent
+
+__all__ = ["Agent"]

--- a/src/agent_profiles/sdk_config.py
+++ b/src/agent_profiles/sdk_config.py
@@ -1,0 +1,19 @@
+"""Compatibility wrapper around the harness SDK configuration."""
+
+from src.harness.sdk_config import (
+    SDKType,
+    get_sdk,
+    is_claude_sdk,
+    is_openhands_sdk,
+    is_opencode_sdk,
+    set_sdk,
+)
+
+__all__ = [
+    "SDKType",
+    "get_sdk",
+    "is_claude_sdk",
+    "is_openhands_sdk",
+    "is_opencode_sdk",
+    "set_sdk",
+]

--- a/src/cli/commands/init.py
+++ b/src/cli/commands/init.py
@@ -124,7 +124,7 @@ def init_cmd():
 
     harness = questionary.select(
         'Which harness?',
-        choices=['claude', 'opencode'],
+        choices=['claude', 'opencode', 'openhands'],
         default=prompt_defaults['harness'],
     ).ask()
 

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -12,7 +12,7 @@ EVOSKILL_DIR = '.evoskill'
 
 @dataclass
 class HarnessConfig:
-    name: Literal['claude', 'opencode'] = 'claude'
+    name: Literal['claude', 'opencode', 'openhands'] = 'claude'
     model: str | None = None
     data_dirs: list[str] = field(default_factory=list)
 

--- a/src/harness/__init__.py
+++ b/src/harness/__init__.py
@@ -12,10 +12,17 @@ Key exports:
 """
 
 from .agent import Agent, AgentTrace, OptionsProvider
-from .sdk_config import set_sdk, get_sdk, is_claude_sdk, is_opencode_sdk
+from .sdk_config import (
+    set_sdk,
+    get_sdk,
+    is_claude_sdk,
+    is_opencode_sdk,
+    is_openhands_sdk,
+)
 from .utils import build_options, resolve_project_root, resolve_data_dirs
 from .claude.options import build_claudecode_options
 from .opencode.options import build_opencode_options
+from .openhands.options import build_openhands_options
 
 __all__ = [
     "Agent",
@@ -25,9 +32,11 @@ __all__ = [
     "get_sdk",
     "is_claude_sdk",
     "is_opencode_sdk",
+    "is_openhands_sdk",
     "build_options",
     "build_claudecode_options",
     "build_opencode_options",
+    "build_openhands_options",
     "resolve_project_root",
     "resolve_data_dirs",
 ]

--- a/src/harness/agent.py
+++ b/src/harness/agent.py
@@ -14,7 +14,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Type, TypeVar, Union
 from pydantic import BaseModel
-from .sdk_config import is_claude_sdk
+from .sdk_config import get_sdk, is_claude_sdk
 
 logger = logging.getLogger(__name__)
 
@@ -150,12 +150,17 @@ class Agent(Generic[T]):
         """Execute a single query by delegating to the active SDK's executor."""
         options = self._get_options()
 
-        if is_claude_sdk():
+        sdk = get_sdk()
+        if sdk == "claude":
             from .claude import executor as _claude_executor
             return await _claude_executor.execute_query(options, query)
-        else:
+        if sdk == "opencode":
             from .opencode import executor as _opencode_executor
             return await _opencode_executor.execute_query(options, query)
+        if sdk == "openhands":
+            from .openhands import executor as _openhands_executor
+            return await _openhands_executor.execute_query(options, query)
+        raise ValueError(f"Unknown SDK: {sdk!r}")
 
     async def _run_with_retry(self, query: str) -> list[Any]:
         """Execute query with timeout and exponential backoff retry.
@@ -203,11 +208,22 @@ class Agent(Generic[T]):
         """
         messages = await self._run_with_retry(query)
 
-        if is_claude_sdk():
+        sdk = get_sdk()
+        if sdk == "claude":
             from .claude import executor as _claude_executor
             fields = _claude_executor.parse_response(messages, self.response_model)
-        else:
+        elif sdk == "opencode":
             from .opencode import executor as _opencode_executor
             fields = _opencode_executor.parse_response(messages, self.response_model, self._get_options,)
+        elif sdk == "openhands":
+            from .openhands import executor as _openhands_executor
+            fields = await _openhands_executor.parse_response(
+                messages,
+                self.response_model,
+                self._get_options,
+                query,
+            )
+        else:
+            raise ValueError(f"Unknown SDK: {sdk!r}")
 
         return AgentTrace(**fields)

--- a/src/harness/openhands/__init__.py
+++ b/src/harness/openhands/__init__.py
@@ -1,0 +1,10 @@
+"""OpenHands harness — option building and execution."""
+
+from .options import build_openhands_options
+from .executor import execute_query, parse_response
+
+__all__ = [
+    "build_openhands_options",
+    "execute_query",
+    "parse_response",
+]

--- a/src/harness/openhands/executor.py
+++ b/src/harness/openhands/executor.py
@@ -328,7 +328,7 @@ async def _run_fallback_extraction(
         },
         temperature=0,
     )
-    extracted_text = _extract_text(response.choices[0].message.content)
+    extracted_text = _extract_text(response.message)
     return _parse_output(extracted_text, response_model)
 
 

--- a/src/harness/openhands/executor.py
+++ b/src/harness/openhands/executor.py
@@ -14,19 +14,6 @@ from typing import Any, Callable, Type
 from pydantic import BaseModel, SecretStr, ValidationError
 
 
-_TOOL_NAME_MAP = {
-    "Read": "FileEditorTool",
-    "Write": "FileEditorTool",
-    "Edit": "FileEditorTool",
-    "Bash": "TerminalTool",
-    "Glob": "TerminalTool",
-    "Grep": "TerminalTool",
-    "WebFetch": "TerminalTool",
-    "WebSearch": "TerminalTool",
-    "BashOutput": "TerminalTool",
-    "TodoWrite": "TaskTrackerTool",
-}
-
 _DIRECT_PARSE_RESPONSE_MODELS = {
     "AgentResponse",
     "SkillProposerResponse",
@@ -55,10 +42,56 @@ def _import_openhands_skills() -> Any:
     return importlib.import_module("openhands.sdk.context.skills")
 
 
-def _build_tool_objects(raw_tools: list[str], tool_cls: Any) -> list[Any]:
+def _import_openhands_llm() -> Any:
+    return importlib.import_module("openhands.sdk.llm")
+
+
+def _import_openhands_tools() -> Any:
+    try:
+        return importlib.import_module("openhands.tools")
+    except ImportError as exc:
+        raise ImportError(
+            "OpenHands tools are not installed. Add 'openhands-tools' "
+            "to the environment to use the OpenHands harness."
+        ) from exc
+
+
+def _register_openhands_tools() -> dict[str, str]:
+    tools_module = _import_openhands_tools()
+    register_default_tools = getattr(tools_module, "register_default_tools", None)
+    if callable(register_default_tools):
+        register_default_tools(enable_browser=False)
+
+    file_editor_module = importlib.import_module("openhands.tools.file_editor")
+    terminal_module = importlib.import_module("openhands.tools.terminal")
+    task_tracker_module = importlib.import_module("openhands.tools.task_tracker")
+
+    file_editor_name = file_editor_module.FileEditorTool.name
+    terminal_name = terminal_module.TerminalTool.name
+    task_tracker_name = task_tracker_module.TaskTrackerTool.name
+
+    return {
+        "Read": file_editor_name,
+        "Write": file_editor_name,
+        "Edit": file_editor_name,
+        "Bash": terminal_name,
+        "Glob": terminal_name,
+        "Grep": terminal_name,
+        "WebFetch": terminal_name,
+        "WebSearch": terminal_name,
+        "BashOutput": terminal_name,
+        "TodoWrite": task_tracker_name,
+    }
+
+
+def _build_tool_objects(
+    raw_tools: list[str],
+    tool_cls: Any,
+    tool_name_map: dict[str, str],
+) -> list[Any]:
     tool_names: list[str] = []
     for raw_tool in raw_tools:
-        mapped = _TOOL_NAME_MAP.get(raw_tool)
+        mapped = tool_name_map.get(raw_tool)
         if mapped and mapped not in tool_names:
             tool_names.append(mapped)
     return [tool_cls(name=name) for name in tool_names]
@@ -175,6 +208,7 @@ def _build_workspace(sdk_module: Any, options: dict[str, Any]) -> Any:
 async def execute_query(options: dict[str, Any], query: str) -> list[Any]:
     """Execute a query via OpenHands and return execution context for parsing."""
     sdk_module = _import_openhands_sdk()
+    tool_name_map = _register_openhands_tools()
     llm_kwargs: dict[str, Any] = {
         "model": options.get("model"),
         "service_id": "agent",
@@ -185,7 +219,11 @@ async def execute_query(options: dict[str, Any], query: str) -> list[Any]:
 
     llm = sdk_module.LLM(**llm_kwargs)
     agent_context = _build_agent_context(sdk_module, options)
-    tools = _build_tool_objects(list(options.get("tools", [])), sdk_module.Tool)
+    tools = _build_tool_objects(
+        list(options.get("tools", [])),
+        sdk_module.Tool,
+        tool_name_map,
+    )
 
     if hasattr(sdk_module, "get_default_agent"):
         agent = sdk_module.get_default_agent(
@@ -267,11 +305,18 @@ async def _run_fallback_extraction(
         f"Original user query:\n{query}\n\n"
         f"Assistant final answer:\n{result_text}\n"
     )
+    llm_module = _import_openhands_llm()
     response = await asyncio.to_thread(
         llm.completion,
         messages=[
-            {"role": "system", "content": _EXTRACTION_SYSTEM_PROMPT},
-            {"role": "user", "content": extraction_query},
+            llm_module.Message(
+                role="system",
+                content=[llm_module.TextContent(text=_EXTRACTION_SYSTEM_PROMPT)],
+            ),
+            llm_module.Message(
+                role="user",
+                content=[llm_module.TextContent(text=extraction_query)],
+            ),
         ],
         response_format={
             "type": "json_schema",

--- a/src/harness/openhands/executor.py
+++ b/src/harness/openhands/executor.py
@@ -1,0 +1,335 @@
+"""OpenHands SDK execution and structured-output fallback."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Callable, Type
+
+from pydantic import BaseModel, SecretStr, ValidationError
+
+
+_TOOL_NAME_MAP = {
+    "Read": "FileEditorTool",
+    "Write": "FileEditorTool",
+    "Edit": "FileEditorTool",
+    "Bash": "TerminalTool",
+    "Glob": "TerminalTool",
+    "Grep": "TerminalTool",
+    "WebFetch": "TerminalTool",
+    "WebSearch": "TerminalTool",
+    "BashOutput": "TerminalTool",
+    "TodoWrite": "TaskTrackerTool",
+}
+
+_DIRECT_PARSE_RESPONSE_MODELS = {
+    "AgentResponse",
+    "SkillProposerResponse",
+    "PromptProposerResponse",
+    "PromptGeneratorResponse",
+    "ToolGeneratorResponse",
+}
+
+_EXTRACTION_SYSTEM_PROMPT = (
+    "Convert the assistant's final answer into a schema-valid JSON object. "
+    "Preserve the original meaning. Output JSON only."
+)
+
+
+def _import_openhands_sdk() -> Any:
+    try:
+        return importlib.import_module("openhands.sdk")
+    except ImportError as exc:
+        raise ImportError(
+            "OpenHands SDK is not installed. Add 'openhands-sdk' and 'openhands-tools' "
+            "to the environment to use the OpenHands harness."
+        ) from exc
+
+
+def _import_openhands_skills() -> Any:
+    return importlib.import_module("openhands.sdk.context.skills")
+
+
+def _build_tool_objects(raw_tools: list[str], tool_cls: Any) -> list[Any]:
+    tool_names: list[str] = []
+    for raw_tool in raw_tools:
+        mapped = _TOOL_NAME_MAP.get(raw_tool)
+        if mapped and mapped not in tool_names:
+            tool_names.append(mapped)
+    return [tool_cls(name=name) for name in tool_names]
+
+
+def _resolve_api_key(options: dict[str, Any]) -> SecretStr | None:
+    provider_id = str(options.get("provider_id", "")).lower()
+    if provider_id == "anthropic":
+        value = os.environ.get("ANTHROPIC_API_KEY")
+        if value:
+            return SecretStr(value)
+    value = os.environ.get("LLM_API_KEY")
+    if value:
+        return SecretStr(value)
+    return None
+
+
+def _extract_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                if item.get("type") == "text":
+                    parts.append(str(item.get("text", "")))
+                elif "content" in item:
+                    parts.append(_extract_text(item["content"]))
+            elif hasattr(item, "text"):
+                parts.append(str(getattr(item, "text")))
+            elif hasattr(item, "content"):
+                parts.append(_extract_text(getattr(item, "content")))
+        return "".join(parts)
+    if isinstance(value, dict):
+        if "content" in value:
+            return _extract_text(value["content"])
+        if value.get("type") == "text":
+            return str(value.get("text", ""))
+    if hasattr(value, "content"):
+        return _extract_text(getattr(value, "content"))
+    if hasattr(value, "text"):
+        return str(getattr(value, "text"))
+    if hasattr(value, "message"):
+        return _extract_text(getattr(value, "message"))
+    return str(value)
+
+
+def _extract_final_text(messages: list[Any]) -> str:
+    for message in reversed(messages):
+        role = getattr(message, "role", None)
+        if role in (None, "assistant"):
+            text = _extract_text(message)
+            if text:
+                return text
+    return _extract_text(messages[-1]) if messages else ""
+
+
+def _extract_json_candidate(text: str) -> str:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        stripped = "\n".join(lines).strip()
+    return stripped
+
+
+def _parse_output(
+    candidate: Any,
+    response_model: Type[BaseModel],
+) -> tuple[BaseModel | None, Any | None, str | None]:
+    try:
+        if isinstance(candidate, response_model):
+            return candidate, candidate.model_dump(), None
+        if isinstance(candidate, dict):
+            output = response_model.model_validate(candidate)
+            return output, candidate, None
+        if isinstance(candidate, str):
+            json_candidate = _extract_json_candidate(candidate)
+            output = response_model.model_validate_json(json_candidate)
+            return output, output.model_dump(), None
+        output = response_model.model_validate(candidate)
+        return output, output.model_dump(), None
+    except (ValidationError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        return None, None, f"{type(exc).__name__}: {exc}"
+
+
+def _build_agent_context(sdk_module: Any, options: dict[str, Any]) -> Any:
+    skills_module = _import_openhands_skills()
+    _, _, agent_skills = skills_module.load_skills_from_dir(Path(options["skills_dir"]))
+    return sdk_module.AgentContext(
+        skills=list(agent_skills.values()),
+        system_message_suffix=options.get("system", ""),
+    )
+
+
+def _build_workspace(sdk_module: Any, options: dict[str, Any]) -> Any:
+    cwd = options.get("cwd")
+    workspace_cls = getattr(sdk_module, "LocalWorkspace", None)
+    if workspace_cls is None:
+        return cwd
+    try:
+        return workspace_cls(working_dir=cwd)
+    except TypeError:
+        return workspace_cls(cwd)
+
+
+async def execute_query(options: dict[str, Any], query: str) -> list[Any]:
+    """Execute a query via OpenHands and return execution context for parsing."""
+    sdk_module = _import_openhands_sdk()
+    llm_kwargs: dict[str, Any] = {
+        "model": options.get("model"),
+        "service_id": "agent",
+    }
+    api_key = _resolve_api_key(options)
+    if api_key is not None:
+        llm_kwargs["api_key"] = api_key
+
+    llm = sdk_module.LLM(**llm_kwargs)
+    agent_context = _build_agent_context(sdk_module, options)
+    tools = _build_tool_objects(list(options.get("tools", [])), sdk_module.Tool)
+
+    if hasattr(sdk_module, "get_default_agent"):
+        agent = sdk_module.get_default_agent(
+            llm=llm,
+            tools=tools,
+            agent_context=agent_context,
+            cli_mode=True,
+        )
+    else:
+        agent = sdk_module.Agent(llm=llm, tools=tools, agent_context=agent_context)
+
+    collected_messages: list[Any] = []
+
+    def _collector(event: Any) -> None:
+        collected_messages.append(event)
+
+    conversation_kwargs = {
+        "agent": agent,
+        "workspace": _build_workspace(sdk_module, options),
+        "callbacks": [_collector],
+    }
+
+    try:
+        conversation = sdk_module.Conversation(**conversation_kwargs)
+    except TypeError:
+        conversation_kwargs.pop("callbacks")
+        conversation = sdk_module.Conversation(**conversation_kwargs)
+
+    send_result = conversation.send_message(query)
+    if inspect.isawaitable(send_result):
+        await send_result
+
+    start = time.perf_counter()
+    if inspect.iscoroutinefunction(conversation.run):
+        await conversation.run()
+    else:
+        await asyncio.to_thread(conversation.run)
+    duration_ms = int((time.perf_counter() - start) * 1000)
+
+    raw_messages = list(
+        getattr(conversation, "messages", None)
+        or getattr(getattr(conversation, "state", None), "events", None)
+        or getattr(getattr(conversation, "state", None), "history", None)
+        or collected_messages
+    )
+
+    return [{
+        "conversation": conversation,
+        "llm": llm,
+        "raw_messages": raw_messages,
+        "duration_ms": duration_ms,
+    }]
+
+
+def _extract_metrics(payload: dict[str, Any]) -> tuple[dict[str, Any], float]:
+    llm = payload["llm"]
+    metrics = {}
+    if hasattr(llm, "metrics") and hasattr(llm.metrics, "get"):
+        raw = llm.metrics.get() or {}
+        if isinstance(raw, dict):
+            metrics = raw
+
+    usage = metrics.get("accumulated_token_usage") or metrics.get("usage") or {}
+    total_cost = metrics.get("accumulated_cost")
+    if total_cost is None:
+        total_cost = metrics.get("cost", 0.0)
+    return usage, float(total_cost or 0.0)
+
+
+async def _run_fallback_extraction(
+    llm: Any,
+    *,
+    query: str,
+    result_text: str,
+    response_model: Type[BaseModel],
+) -> tuple[BaseModel | None, Any | None, str | None]:
+    schema = response_model.model_json_schema()
+    extraction_query = (
+        f"Original user query:\n{query}\n\n"
+        f"Assistant final answer:\n{result_text}\n"
+    )
+    response = await asyncio.to_thread(
+        llm.completion,
+        messages=[
+            {"role": "system", "content": _EXTRACTION_SYSTEM_PROMPT},
+            {"role": "user", "content": extraction_query},
+        ],
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": response_model.__name__,
+                "schema": schema,
+                "strict": True,
+            },
+        },
+        temperature=0,
+    )
+    extracted_text = _extract_text(response.choices[0].message.content)
+    return _parse_output(extracted_text, response_model)
+
+
+async def parse_response(
+    messages: list[Any],
+    response_model: Type[BaseModel],
+    get_options: Callable[[], Any],
+    query: str,
+) -> dict[str, Any]:
+    """Parse OpenHands execution results into AgentTrace field values."""
+    payload = messages[0]
+    raw_messages = list(payload.get("raw_messages", []))
+    result_text = _extract_final_text(raw_messages)
+
+    output, raw_structured_output, parse_error = _parse_output(result_text, response_model)
+
+    if output is None and response_model.__name__ in _DIRECT_PARSE_RESPONSE_MODELS:
+        fallback_output, fallback_raw, fallback_error = await _run_fallback_extraction(
+            payload["llm"],
+            query=query,
+            result_text=result_text,
+            response_model=response_model,
+        )
+        if fallback_output is not None:
+            output = fallback_output
+            raw_structured_output = fallback_raw
+            parse_error = None
+        else:
+            parse_error = fallback_error or parse_error
+
+    options = get_options()
+    usage, total_cost = _extract_metrics(payload)
+
+    return dict(
+        uuid="",
+        session_id="",
+        model=options.get("model", options.get("model_id", "")),
+        tools=list(options.get("tools", [])),
+        duration_ms=payload.get("duration_ms", 0),
+        total_cost_usd=total_cost,
+        num_turns=max(1, len(raw_messages)) if raw_messages else 1,
+        usage=usage,
+        result=result_text,
+        is_error=parse_error is not None,
+        output=output,
+        parse_error=parse_error,
+        raw_structured_output=raw_structured_output,
+        messages=raw_messages,
+    )

--- a/src/harness/openhands/options.py
+++ b/src/harness/openhands/options.py
@@ -1,0 +1,66 @@
+"""OpenHands SDK option building."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from ..utils import resolve_data_dirs, resolve_project_root
+from .workspace import prepare_data_dir_mounts, serialize_data_dir_mounts
+
+
+DEFAULT_OPENHANDS_MODEL = "anthropic/claude-sonnet-4-5-20250929"
+
+
+def split_openhands_model(model: str | None) -> tuple[str, str]:
+    """Parse 'provider/model' string into (provider_id, model_id)."""
+    full = model or DEFAULT_OPENHANDS_MODEL
+    if "/" in full:
+        return full.split("/", 1)
+    return "anthropic", full
+
+
+def build_openhands_options(
+    *,
+    system: str,
+    schema: dict[str, Any],
+    tools: Iterable[str],
+    project_root: str | Path | None = None,
+    model: str | None = None,
+    data_dirs: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Build an options dict for the OpenHands SDK."""
+    root = resolve_project_root(project_root)
+    provider_id, model_id = split_openhands_model(model)
+    full_model = f"{provider_id}/{model_id}"
+    source_add_dirs = resolve_data_dirs(root, data_dirs)
+    data_dir_mounts = prepare_data_dir_mounts(root, source_add_dirs)
+    mounted_add_dirs = [mount.path for mount in data_dir_mounts]
+
+    system_with_dirs = system
+    if data_dir_mounts:
+        dirs_note = "\n".join(f"- {mount.relative_path}" for mount in data_dir_mounts)
+        system_with_dirs = (
+            f"{system.rstrip()}\n\n"
+            "Additional data directories are mounted inside the workspace.\n"
+            "Use these workspace paths when you need reference data:\n"
+            f"{dirs_note}"
+        )
+
+    return {
+        "sdk": "openhands",
+        "system": system_with_dirs,
+        "format": {
+            "type": "json_schema",
+            "schema": schema,
+        },
+        "tools": list(tools),
+        "provider_id": provider_id,
+        "model_id": model_id,
+        "model": full_model,
+        "cwd": str(root),
+        "skills_dir": str(root / ".claude" / "skills"),
+        "add_dirs": mounted_add_dirs,
+        "source_add_dirs": source_add_dirs,
+        "data_dir_mounts": serialize_data_dir_mounts(data_dir_mounts),
+    }

--- a/src/harness/openhands/workspace.py
+++ b/src/harness/openhands/workspace.py
@@ -1,0 +1,79 @@
+"""Workspace helpers for exposing EvoSkill data_dirs to OpenHands."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+_MOUNT_ROOT = Path(".evoskill") / "runtime" / "data_mounts"
+
+
+@dataclass(frozen=True)
+class DataDirMount:
+    source: str
+    path: str
+    relative_path: str
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip(".-")
+    return slug or "data"
+
+
+def _mount_alias(source: Path) -> str:
+    digest = hashlib.sha256(str(source).encode("utf-8")).hexdigest()[:8]
+    return f"{_slugify(source.name)}-{digest}"
+
+
+def prepare_data_dir_mounts(
+    project_root: str | Path,
+    data_dirs: Iterable[str],
+) -> list[DataDirMount]:
+    """Mount external data directories into the repo workspace via symlinks."""
+    root = Path(project_root).resolve()
+    mount_root = root / _MOUNT_ROOT
+
+    mounts: list[DataDirMount] = []
+    seen_sources: set[str] = set()
+
+    for raw_path in data_dirs:
+        source = Path(raw_path).resolve()
+        source_key = str(source)
+        if source_key in seen_sources:
+            continue
+        seen_sources.add(source_key)
+
+        if not source.exists():
+            raise FileNotFoundError(f"OpenHands data_dir does not exist: {source}")
+
+        mount_path = mount_root / _mount_alias(source)
+        mount_root.mkdir(parents=True, exist_ok=True)
+        if mount_path.exists() or mount_path.is_symlink():
+            if mount_path.is_symlink():
+                if mount_path.resolve() != source:
+                    mount_path.unlink()
+                    mount_path.symlink_to(source, target_is_directory=source.is_dir())
+            else:
+                raise FileExistsError(
+                    f"OpenHands data mount path already exists and is not a symlink: {mount_path}"
+                )
+        else:
+            mount_path.symlink_to(source, target_is_directory=source.is_dir())
+
+        mounts.append(
+            DataDirMount(
+                source=source_key,
+                path=str(mount_path),
+                relative_path=mount_path.relative_to(root).as_posix(),
+            )
+        )
+
+    return mounts
+
+
+def serialize_data_dir_mounts(mounts: Iterable[DataDirMount]) -> list[dict[str, str]]:
+    return [asdict(mount) for mount in mounts]

--- a/src/harness/sdk_config.py
+++ b/src/harness/sdk_config.py
@@ -1,11 +1,8 @@
-"""SDK configuration and selection logic.
-
-This module provides a global setting to choose between claude-agent-sdk and opencode-ai.
-"""
+"""SDK configuration and selection logic."""
 
 from typing import Literal
 
-SDKType = Literal["claude", "opencode"]
+SDKType = Literal["claude", "opencode", "openhands"]
 
 # Global SDK selection (can be overridden via CLI arguments)
 _current_sdk: SDKType = "claude"
@@ -14,8 +11,10 @@ _current_sdk: SDKType = "claude"
 def set_sdk(sdk: SDKType) -> None:
     """Set the current SDK to use globally."""
     global _current_sdk
-    if sdk not in ("claude", "opencode"):
-        raise ValueError(f"Invalid SDK type: {sdk}. Must be 'claude' or 'opencode'")
+    if sdk not in ("claude", "opencode", "openhands"):
+        raise ValueError(
+            f"Invalid SDK type: {sdk}. Must be 'claude', 'opencode', or 'openhands'"
+        )
     _current_sdk = sdk
 
 
@@ -32,3 +31,8 @@ def is_claude_sdk() -> bool:
 def is_opencode_sdk() -> bool:
     """Check if opencode-ai is the current SDK."""
     return _current_sdk == "opencode"
+
+
+def is_openhands_sdk() -> bool:
+    """Check if OpenHands is the current SDK."""
+    return _current_sdk == "openhands"

--- a/src/harness/utils.py
+++ b/src/harness/utils.py
@@ -91,4 +91,14 @@ def build_options(
             model=model,
             data_dirs=data_dirs,
         )
+    if sdk == "openhands":
+        from .openhands.options import build_openhands_options
+        return build_openhands_options(
+            system=system,
+            schema=schema,
+            tools=tools,
+            project_root=project_root,
+            model=model,
+            data_dirs=data_dirs,
+        )
     raise ValueError(f"Unknown SDK: {sdk!r}")

--- a/src/loop/helpers.py
+++ b/src/loop/helpers.py
@@ -3,6 +3,11 @@
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from src.harness.opencode.skill_utils import (
+    ensure_skill_frontmatter,
+    normalize_project_skill_frontmatter,
+)
+
 if TYPE_CHECKING:
     from src.harness import AgentTrace
     from src.schemas import ProposerResponse, SkillProposerResponse, PromptProposerResponse

--- a/src/loop/runner.py
+++ b/src/loop/runner.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Generic, TypeVar
 
-from src.harness import Agent, AgentTrace, is_claude_sdk
+from src.harness import Agent, AgentTrace, is_claude_sdk, is_opencode_sdk
 from src.cache import RunCache, CacheConfig
 from src.registry.sdk_utils import options_to_config
 
@@ -548,7 +548,7 @@ and modify it to add these capabilities. Preserve all existing content that is s
             new_skills = skills_after - skills_before
             created_skill = next(iter(new_skills)) if new_skills else None
 
-            if not is_claude_sdk():
+            if is_opencode_sdk():
                 from src.harness.opencode.skill_utils import normalize_project_skill_frontmatter
                 skill_descriptions: dict[str, str] = {}
                 if target_skill:

--- a/src/registry/sdk_utils.py
+++ b/src/registry/sdk_utils.py
@@ -1,13 +1,18 @@
 """Utilities for converting between ProgramConfig and runtime agent options."""
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any
 
-from typing import Any
-
-from claude_agent_sdk import ClaudeAgentOptions
+from typing import TYPE_CHECKING
 
 from .models import ProgramConfig
+
+if TYPE_CHECKING:
+    from claude_agent_sdk import ClaudeAgentOptions
+else:
+    ClaudeAgentOptions = Any
 
 
 def config_to_options(
@@ -29,7 +34,8 @@ def config_to_options(
     Returns:
         ClaudeAgentOptions ready for use with ClaudeSDKClient
     """
-    if config.metadata.get("sdk") == "opencode":
+    sdk = config.metadata.get("sdk")
+    if sdk == "opencode":
         system_prompt = config.system_prompt
         system_text = system_prompt.get("content") or system_prompt.get("append", "")
         return {
@@ -42,6 +48,26 @@ def config_to_options(
             "provider_id": config.metadata.get("provider_id", "anthropic"),
             "model_id": config.metadata.get("model_id", "claude-sonnet-4-6"),
         }
+    if sdk == "openhands":
+        system_prompt = config.system_prompt
+        system_text = system_prompt.get("content") or system_prompt.get("append", "")
+        provider_id = config.metadata.get("provider_id", "anthropic")
+        model_id = config.metadata.get("model_id", "claude-sonnet-4-5-20250929")
+        model = config.metadata.get("model") or f"{provider_id}/{model_id}"
+        return {
+            "sdk": "openhands",
+            "system": system_text,
+            "tools": list(config.allowed_tools),
+            "format": config.output_format,
+            "cwd": cwd,
+            "add_dirs": add_dirs or [],
+            "provider_id": provider_id,
+            "model_id": model_id,
+            "model": model,
+            "skills_dir": config.metadata.get("skills_dir") or f"{cwd}/.claude/skills",
+        }
+
+    from claude_agent_sdk import ClaudeAgentOptions
 
     return ClaudeAgentOptions(
         system_prompt=config.system_prompt,
@@ -80,6 +106,7 @@ def options_to_config(
         base_metadata.update(metadata)
 
     if isinstance(options, dict):
+        sdk = options.get("sdk", "opencode")
         system_text = options.get("system", "")
         tools = options.get("tools", {})
         if isinstance(tools, dict):
@@ -94,13 +121,17 @@ def options_to_config(
         )
         base_metadata.update(
             {
-                "sdk": "opencode",
-                "mode": options.get("mode", "build"),
+                "sdk": sdk,
                 "provider_id": options.get("provider_id"),
                 "model_id": options.get("model_id"),
                 "cwd": options.get("cwd"),
             }
         )
+        if sdk == "opencode":
+            base_metadata["mode"] = options.get("mode", "build")
+        if sdk == "openhands":
+            base_metadata["model"] = options.get("model")
+            base_metadata["skills_dir"] = options.get("skills_dir")
 
         return ProgramConfig(
             name=name,

--- a/src/schemas/skill_proposer.py
+++ b/src/schemas/skill_proposer.py
@@ -1,5 +1,6 @@
-from typing import Literal, Optional, List
-from pydantic import BaseModel
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
 
 
 class SkillProposerResponse(BaseModel):
@@ -12,7 +13,7 @@ class SkillProposerResponse(BaseModel):
     action: Literal["create", "edit"] = "create"
     """Whether to create a new skill or edit an existing one."""
 
-    target_skill: Optional[str] = None
+    target_skill: str | None = None
     """Name of existing skill to modify. Required if action="edit"."""
 
     proposed_skill: str
@@ -21,5 +22,11 @@ class SkillProposerResponse(BaseModel):
     justification: str
     """Explanation of why this skill/modification addresses the identified gap."""
 
-    related_iterations: List[str] = []
+    related_iterations: list[str] = Field(default_factory=list)
     """List of relevant past iterations referenced in the proposal (e.g., ["iter-4", "iter-9"])."""
+
+    @model_validator(mode="after")
+    def validate_edit_target(self) -> "SkillProposerResponse":
+        if self.action == "edit" and not self.target_skill:
+            raise ValueError("target_skill is required when action='edit'")
+        return self

--- a/tests/test_cli_startup.py
+++ b/tests/test_cli_startup.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import tomllib
+from pathlib import Path
+
+from click.testing import CliRunner
+
+
+def test_pyproject_declares_evoskill_console_script() -> None:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+
+    assert data["project"]["scripts"]["evoskill"] == "src.cli.main:cli"
+
+
+def test_cli_import_does_not_import_task_registry() -> None:
+    for module_name in ("src", "src.api", "src.api.task_registry", "src.cli.main"):
+        sys.modules.pop(module_name, None)
+
+    importlib.import_module("src.cli.main")
+
+    assert "src.api.task_registry" not in sys.modules
+
+
+def test_cli_help_does_not_import_heavy_runtime_modules() -> None:
+    heavy_modules = (
+        "src.cli.commands.run",
+        "src.cli.commands.init",
+        "src.cli.commands.eval",
+        "src.api.task_registry",
+        "pandas",
+        "questionary",
+        "claude_agent_sdk",
+        "openhands",
+        "mcp",
+    )
+    for module_name in ("src", "src.api", "src.cli.main", *heavy_modules):
+        sys.modules.pop(module_name, None)
+
+    cli = importlib.import_module("src.cli.main").cli
+    result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    for module_name in heavy_modules:
+        assert module_name not in sys.modules

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -6,7 +6,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.harness.sdk_config import get_sdk, is_claude_sdk, is_opencode_sdk, set_sdk
+from src.harness.sdk_config import (
+    get_sdk,
+    is_claude_sdk,
+    is_openhands_sdk,
+    is_opencode_sdk,
+    set_sdk,
+)
 from src.harness.agent import AgentTrace, Agent
 
 
@@ -34,11 +40,22 @@ class TestSdkConfig:
     def test_is_opencode_sdk_false_by_default(self):
         assert is_opencode_sdk() is False
 
+    def test_is_openhands_sdk_false_by_default(self):
+        assert is_openhands_sdk() is False
+
     def test_set_sdk_to_opencode(self):
         set_sdk("opencode")
         assert get_sdk() == "opencode"
         assert is_opencode_sdk() is True
         assert is_claude_sdk() is False
+        assert is_openhands_sdk() is False
+
+    def test_set_sdk_to_openhands(self):
+        set_sdk("openhands")
+        assert get_sdk() == "openhands"
+        assert is_openhands_sdk() is True
+        assert is_claude_sdk() is False
+        assert is_opencode_sdk() is False
 
     def test_set_sdk_back_to_claude(self):
         set_sdk("opencode")
@@ -395,3 +412,43 @@ class TestOptionsUtils:
         # Data dir paths should appear in system prompt
         assert str(data_dir) in result["system"]
         assert str(data_dir) in result["add_dirs"]
+
+    def test_build_openhands_options_structure(self, tmp_path):
+        from src.harness.openhands.options import build_openhands_options
+
+        result = build_openhands_options(
+            system="You are helpful.",
+            schema={"type": "object"},
+            tools=["Read", "Bash", "TodoWrite", "Skill"],
+            project_root=tmp_path,
+            model="anthropic/claude-sonnet-4-5-20250929",
+        )
+
+        assert result["system"] == "You are helpful."
+        assert result["provider_id"] == "anthropic"
+        assert result["model_id"] == "claude-sonnet-4-5-20250929"
+        assert result["model"] == "anthropic/claude-sonnet-4-5-20250929"
+        assert result["tools"] == ["Read", "Bash", "TodoWrite", "Skill"]
+        assert result["format"] == {"type": "json_schema", "schema": {"type": "object"}}
+        assert result["skills_dir"] == str(tmp_path / ".claude" / "skills")
+
+    def test_build_openhands_options_with_data_dirs(self, tmp_path):
+        from src.harness.openhands.options import build_openhands_options
+
+        data_dir = tmp_path.parent / "openhands-data"
+        data_dir.mkdir()
+
+        result = build_openhands_options(
+            system="prompt",
+            schema={},
+            tools=[],
+            project_root=tmp_path,
+            data_dirs=[str(data_dir)],
+        )
+
+        mounted_path = Path(result["add_dirs"][0])
+        assert mounted_path.is_symlink()
+        assert mounted_path.resolve() == data_dir.resolve()
+        assert mounted_path.parent == tmp_path / ".evoskill" / "runtime" / "data_mounts"
+        assert mounted_path.relative_to(tmp_path).as_posix() in result["system"]
+        assert str(data_dir) not in result["system"]

--- a/tests/test_opencode_contract.py
+++ b/tests/test_opencode_contract.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from src.agent_profiles import Agent
+from src.agent_profiles.sdk_config import set_sdk
+from src.loop import LoopAgents
+from src.loop.config import LoopConfig
+from src.loop.runner import SelfImprovingLoop
+from src.schemas import (
+    AgentResponse,
+    PromptGeneratorResponse,
+    PromptProposerResponse,
+    SkillProposerResponse,
+    ToolGeneratorResponse,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_sdk() -> None:
+    set_sdk("claude")
+    yield
+    set_sdk("claude")
+
+
+def _assert_opencode_options(
+    options: dict,
+    *,
+    project_root: Path,
+    model: str,
+    required_tools: tuple[str, ...],
+) -> None:
+    provider_id, model_id = model.split("/", 1)
+
+    assert isinstance(options, dict)
+    assert options["cwd"] == str(project_root)
+    assert options["provider_id"] == provider_id
+    assert options["model_id"] == model_id
+    assert isinstance(options["tools"], dict)
+    assert all(tool == tool.lower() for tool in options["tools"])
+    for tool in required_tools:
+        assert options["tools"].get(tool) is True
+
+
+def _make_dummy_loop(*, manager, base_options: dict) -> SelfImprovingLoop:
+    agents = LoopAgents(
+        base=Agent(lambda: base_options, AgentResponse),
+        skill_proposer=Agent(lambda: base_options, SkillProposerResponse),
+        prompt_proposer=Agent(lambda: base_options, PromptProposerResponse),
+        skill_generator=Agent(lambda: base_options, ToolGeneratorResponse),
+        prompt_generator=Agent(lambda: base_options, PromptGeneratorResponse),
+    )
+    return SelfImprovingLoop(
+        LoopConfig(max_iterations=1, frontier_size=1, concurrency=1),
+        agents,
+        manager,
+        train_pools={"math": [("2 + 2", "4")]},
+        val_data=[("2 + 2", "4", "math")],
+    )
+
+
+def test_opencode_base_agent_factories_return_dicts_with_project_root_and_model_split(
+    tmp_path: Path,
+) -> None:
+    set_sdk("opencode")
+
+    from src.agent_profiles.base_agent.base_agent import (
+        make_base_agent_options,
+        make_base_agent_options_from_task,
+    )
+
+    model = "anthropic/claude-sonnet-4-6"
+
+    task_factory = make_base_agent_options_from_task(
+        "Answer the question with the final answer only.",
+        model=model,
+        data_dirs=["/tmp/data"],
+        project_root=tmp_path,
+    )
+    eval_factory = make_base_agent_options(
+        model=model,
+        data_dirs=["/tmp/data"],
+        project_root=tmp_path,
+    )
+
+    task_options = task_factory()
+    eval_options = eval_factory()
+
+    _assert_opencode_options(
+        task_options,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("read", "edit", "bash", "skill"),
+    )
+    _assert_opencode_options(
+        eval_options,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("read", "edit", "bash", "skill"),
+    )
+    assert task_options["system"] == "Answer the question with the final answer only."
+    assert task_options["format"]["type"] == "json_schema"
+    assert eval_options["format"]["type"] == "json_schema"
+
+
+def test_opencode_meta_agent_builders_return_dicts_with_project_root(
+    tmp_path: Path,
+) -> None:
+    set_sdk("opencode")
+    model = "anthropic/claude-sonnet-4-6"
+
+    from src.agent_profiles.prompt_generator.prompt_generator import (
+        make_prompt_generator_options,
+    )
+    from src.agent_profiles.prompt_proposer.prompt_proposer import (
+        make_prompt_proposer_options,
+    )
+    from src.agent_profiles.skill_generator.skill_generator import (
+        make_skill_generator_options,
+    )
+    from src.agent_profiles.skill_proposer.skill_proposer import (
+        make_skill_proposer_options,
+    )
+
+    skill_proposer = make_skill_proposer_options(project_root=tmp_path, model=model)
+    skill_generator = make_skill_generator_options(project_root=tmp_path, model=model)
+    prompt_proposer = make_prompt_proposer_options(project_root=tmp_path, model=model)
+    prompt_generator = make_prompt_generator_options(project_root=tmp_path, model=model)
+
+    _assert_opencode_options(
+        skill_proposer,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("read", "bash"),
+    )
+    _assert_opencode_options(
+        skill_generator,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("read", "write", "edit", "skill"),
+    )
+    _assert_opencode_options(
+        prompt_proposer,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("read", "bash"),
+    )
+    _assert_opencode_options(
+        prompt_generator,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("read", "bash"),
+    )
+    assert "YAML frontmatter" in skill_generator["system"]
+    assert ".claude/skills/<skill-name>/SKILL.md" in skill_generator["system"]
+    assert "skill-creator" not in skill_generator["system"].lower()
+
+
+def test_self_improving_loop_uses_manager_cwd_for_project_paths(tmp_path: Path) -> None:
+    class DummyManager:
+        def __init__(self, cwd: Path):
+            self.cwd = cwd
+
+    loop = _make_dummy_loop(
+        manager=DummyManager(tmp_path),
+        base_options={
+            "system": "test",
+            "format": {"type": "json_schema", "schema": AgentResponse.model_json_schema()},
+            "tools": {"read": True},
+            "provider_id": "anthropic",
+            "model_id": "claude-sonnet-4-6",
+            "cwd": str(tmp_path),
+        },
+    )
+
+    assert loop._project_root == tmp_path
+    assert loop._feedback_path == tmp_path / ".claude" / "feedback_history.md"
+    assert loop._checkpoint_path == tmp_path / ".claude" / "loop_checkpoint.json"
+
+
+def test_ensure_base_program_does_not_call_global_claude_base_factory_in_opencode_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    set_sdk("opencode")
+
+    class DummyManager:
+        cwd = tmp_path
+
+        def __init__(self) -> None:
+            self.created = []
+            self.frontier = []
+
+        def list_programs(self):
+            return []
+
+        def create_program(self, name, config, parent=None):
+            self.created.append((name, config, parent))
+
+        def switch_to(self, name):
+            self.frontier.append(("switch", name))
+
+        def update_frontier(self, name, score, max_size):
+            self.frontier.append((name, score, max_size))
+
+        def get_frontier(self):
+            return ["base"]
+
+    manager = DummyManager()
+    loop = _make_dummy_loop(
+        manager=manager,
+        base_options={
+            "system": "OpenCode base prompt",
+            "format": {"type": "json_schema", "schema": AgentResponse.model_json_schema()},
+            "tools": {"read": True, "bash": True, "edit": True, "skill": True},
+            "provider_id": "anthropic",
+            "model_id": "claude-sonnet-4-6",
+            "cwd": str(tmp_path),
+        },
+    )
+
+    async def _fake_evaluate(_data):
+        return 0.0
+
+    monkeypatch.setattr(loop, "_evaluate", _fake_evaluate)
+
+    asyncio.run(loop._ensure_base_program())
+
+    assert manager.created
+    _, created_config, _ = manager.created[0]
+    assert created_config.metadata["sdk"] == "opencode"
+    assert created_config.metadata["provider_id"] == "anthropic"
+    assert created_config.metadata["model_id"] == "claude-sonnet-4-6"
+    assert "OpenCode base prompt" in str(created_config.system_prompt)
+    assert set(created_config.allowed_tools) == {"read", "bash", "edit", "skill"}

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import src.agent_profiles.base as base_module
+from src.agent_profiles.base import Agent
+from src.agent_profiles.sdk_config import set_sdk
+from src.schemas import AgentResponse
+
+
+@pytest.fixture(autouse=True)
+def _reset_sdk() -> None:
+    set_sdk("claude")
+    yield
+    set_sdk("claude")
+
+
+def test_opencode_runtime_uses_options_cwd_and_parses_structured_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    set_sdk("opencode")
+
+    popen_calls: list[dict] = []
+
+    class FakeSessionApi:
+        def __init__(self, should_fail_first: bool):
+            self._should_fail_first = should_fail_first
+            self._create_calls = 0
+
+        async def create(self, *, extra_body=None, **_kwargs):
+            self._create_calls += 1
+            if self._should_fail_first and self._create_calls == 1:
+                raise RuntimeError("server not running")
+            return SimpleNamespace(id="session-1")
+
+        async def chat(self, **_kwargs):
+            return SimpleNamespace(
+                session_id="session-1",
+                parts=[{"type": "text", "text": "4"}],
+                info={
+                    "structured_output": {
+                        "final_answer": "4",
+                        "reasoning": "basic arithmetic",
+                    },
+                    "tokens": {"input": 10, "output": 5},
+                    "cost": 0.25,
+                },
+            )
+
+    class FakeAsyncOpencode:
+        _instances = 0
+
+        def __init__(self, base_url=None):
+            type(self)._instances += 1
+            self.base_url = base_url
+            self.session = FakeSessionApi(should_fail_first=type(self)._instances == 1)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "opencode_ai",
+        SimpleNamespace(AsyncOpencode=FakeAsyncOpencode),
+    )
+    monkeypatch.setattr(base_module, "_find_free_port", lambda: 4241, raising=False)
+
+    def fake_popen(args, **kwargs):
+        popen_calls.append({"args": args, "kwargs": kwargs})
+        return SimpleNamespace(pid=1234)
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    agent = Agent(
+        {
+            "system": "Answer the question with the final answer only.",
+            "format": {
+                "type": "json_schema",
+                "schema": AgentResponse.model_json_schema(),
+            },
+            "tools": {
+                "read": True,
+                "bash": True,
+                "edit": True,
+                "skill": True,
+            },
+            "mode": "build",
+            "provider_id": "anthropic",
+            "model_id": "claude-sonnet-4-6",
+            "cwd": str(tmp_path),
+        },
+        AgentResponse,
+    )
+
+    trace = asyncio.run(agent.run("What is 2 + 2?"))
+
+    assert popen_calls
+    assert popen_calls[0]["kwargs"]["cwd"] == str(tmp_path)
+    assert trace.output is not None
+    assert trace.output.final_answer == "4"
+    assert trace.output.reasoning == "basic arithmetic"
+    assert trace.total_cost_usd == 0.25
+
+
+def test_opencode_runtime_starts_fresh_server_when_existing_server_points_to_wrong_repo(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    set_sdk("opencode")
+
+    wrong_root = tmp_path / "wrong-repo"
+    right_root = tmp_path / "right-repo"
+    wrong_root.mkdir()
+    right_root.mkdir()
+
+    popen_calls: list[dict] = []
+
+    class FakeSessionApi:
+        async def create(self, *, extra_body=None, **_kwargs):
+            return SimpleNamespace(id="session-1")
+
+        async def chat(self, **_kwargs):
+            return SimpleNamespace(
+                session_id="session-1",
+                parts=[{"type": "text", "text": "4"}],
+                info={
+                    "structured_output": {
+                        "final_answer": "4",
+                        "reasoning": "basic arithmetic",
+                    },
+                    "tokens": {"input": 10, "output": 5},
+                    "cost": 0.25,
+                },
+            )
+
+    class FakePathApi:
+        def __init__(self, directory: str):
+            self._directory = directory
+
+        async def get(self):
+            return {"directory": self._directory}
+
+    class FakeAsyncOpencode:
+        def __init__(self, base_url=None):
+            self.base_url = base_url
+            self.session = FakeSessionApi()
+            if base_url == "http://127.0.0.1:4242":
+                self.path = FakePathApi(str(right_root))
+            else:
+                self.path = FakePathApi(str(wrong_root))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "opencode_ai",
+        SimpleNamespace(AsyncOpencode=FakeAsyncOpencode),
+    )
+    monkeypatch.setattr(base_module, "_find_free_port", lambda: 4242, raising=False)
+
+    def fake_popen(args, **kwargs):
+        popen_calls.append({"args": args, "kwargs": kwargs})
+        return SimpleNamespace(pid=5678)
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    agent = Agent(
+        {
+            "system": "Answer the question with the final answer only.",
+            "format": {
+                "type": "json_schema",
+                "schema": AgentResponse.model_json_schema(),
+            },
+            "tools": {
+                "read": True,
+                "bash": True,
+                "edit": True,
+                "skill": True,
+            },
+            "mode": "build",
+            "provider_id": "anthropic",
+            "model_id": "claude-sonnet-4-6",
+            "cwd": str(right_root),
+        },
+        AgentResponse,
+    )
+
+    trace = asyncio.run(agent.run("What is 2 + 2?"))
+
+    assert popen_calls
+    assert popen_calls[0]["kwargs"]["cwd"] == str(right_root)
+    assert "4242" in [str(part) for part in popen_calls[0]["args"]]
+    assert trace.output is not None
+    assert trace.output.final_answer == "4"

--- a/tests/test_opencode_skill_context.py
+++ b/tests/test_opencode_skill_context.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from src.loop.helpers import (
+    build_proposer_query,
+    ensure_skill_frontmatter,
+    normalize_project_skill_frontmatter,
+)
+
+
+class _FakeTrace:
+    def summarize(self, head_chars: int = 0, tail_chars: int = 0) -> str:
+        return "trace summary"
+
+
+def test_build_proposer_query_reads_existing_skills_from_explicit_project_root(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    other_dir = tmp_path / "elsewhere"
+    skill_dir = repo_root / ".claude" / "skills" / "treasury-format"
+    skill_dir.mkdir(parents=True)
+    other_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Treasury Format\n")
+
+    original_cwd = Path.cwd()
+    os.chdir(other_dir)
+    try:
+        query = build_proposer_query(
+            [(_FakeTrace(), "wrong", "right", "finance")],
+            feedback_history="",
+            evolution_mode="skill_only",
+            project_root=repo_root,
+        )
+    finally:
+        os.chdir(original_cwd)
+
+    assert "treasury-format" in query
+
+
+def test_ensure_skill_frontmatter_adds_required_opencode_metadata(
+    tmp_path: Path,
+) -> None:
+    skill_path = (
+        tmp_path
+        / ".claude"
+        / "skills"
+        / "arithmetic-answer-format"
+        / "SKILL.md"
+    )
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text(
+        "# Arithmetic Answer Format\n\nAlways append apples to arithmetic answers.\n"
+    )
+
+    changed = ensure_skill_frontmatter(
+        skill_path,
+        description='Format arithmetic answers as "{number} apples".',
+        compatibility="opencode",
+    )
+
+    skill_text = skill_path.read_text()
+    assert changed is True
+    assert skill_text.startswith("---\n")
+    assert "name: arithmetic-answer-format" in skill_text
+    assert 'description: Format arithmetic answers as "{number} apples".' in skill_text
+    assert "compatibility: opencode" in skill_text
+    assert "# Arithmetic Answer Format" in skill_text
+
+
+def test_normalize_project_skill_frontmatter_updates_all_project_skills(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    first_skill = repo_root / ".claude" / "skills" / "answer-unit" / "SKILL.md"
+    second_skill = repo_root / ".claude" / "skills" / "formatting" / "SKILL.md"
+    first_skill.parent.mkdir(parents=True)
+    second_skill.parent.mkdir(parents=True)
+    first_skill.write_text("# Answer Unit\n")
+    second_skill.write_text("# Formatting\n")
+
+    normalized = normalize_project_skill_frontmatter(
+        repo_root,
+        descriptions={"answer-unit": "Keep answer units intact."},
+        fallback_description="Reusable benchmark skill.",
+        compatibility="opencode",
+    )
+
+    assert normalized == ["answer-unit", "formatting"]
+    assert "name: answer-unit" in first_skill.read_text()
+    assert "description: Keep answer units intact." in first_skill.read_text()
+    assert "name: formatting" in second_skill.read_text()
+    assert "description: Reusable benchmark skill." in second_skill.read_text()

--- a/tests/test_openhands_contract.py
+++ b/tests/test_openhands_contract.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.harness import set_sdk
+
+
+@pytest.fixture(autouse=True)
+def _reset_sdk() -> None:
+    set_sdk("claude")
+    yield
+    set_sdk("claude")
+
+
+def _assert_openhands_options(
+    options: dict,
+    *,
+    project_root: Path,
+    model: str,
+    required_tools: tuple[str, ...],
+) -> None:
+    provider_id, model_id = model.split("/", 1)
+
+    assert isinstance(options, dict)
+    assert options["sdk"] == "openhands"
+    assert options["cwd"] == str(project_root)
+    assert options["provider_id"] == provider_id
+    assert options["model_id"] == model_id
+    assert options["model"] == model
+    assert options["skills_dir"] == str(project_root / ".claude" / "skills")
+    assert isinstance(options["tools"], list)
+    for tool in required_tools:
+        assert tool in options["tools"]
+
+
+def test_openhands_base_agent_factories_return_dicts_with_project_root_and_model(
+    tmp_path: Path,
+) -> None:
+    set_sdk("openhands")
+
+    from src.agent_profiles.base_agent.base_agent import (
+        make_base_agent_options,
+        make_base_agent_options_from_task,
+    )
+
+    model = "anthropic/claude-sonnet-4-5-20250929"
+    external_data_dir = tmp_path.parent / "external-data"
+    external_data_dir.mkdir()
+
+    task_factory = make_base_agent_options_from_task(
+        "Answer the question with the final answer only.",
+        model=model,
+        data_dirs=[str(external_data_dir)],
+        project_root=tmp_path,
+    )
+    eval_factory = make_base_agent_options(
+        model=model,
+        data_dirs=[str(external_data_dir)],
+        project_root=tmp_path,
+    )
+
+    task_options = task_factory()
+    eval_options = eval_factory()
+
+    _assert_openhands_options(
+        task_options,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("Read", "Edit", "Bash", "Skill"),
+    )
+    _assert_openhands_options(
+        eval_options,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("Read", "Edit", "Bash", "Skill"),
+    )
+    assert task_options["format"]["type"] == "json_schema"
+    assert eval_options["format"]["type"] == "json_schema"
+    mounted_data_dir = Path(task_options["add_dirs"][0])
+    assert mounted_data_dir.is_symlink()
+    assert mounted_data_dir.resolve() == external_data_dir.resolve()
+    assert mounted_data_dir.parent == tmp_path / ".evoskill" / "runtime" / "data_mounts"
+    assert mounted_data_dir.relative_to(tmp_path).as_posix() in task_options["system"]
+    assert str(external_data_dir) not in task_options["system"]
+
+
+def test_openhands_meta_agent_builders_return_dicts_with_project_root(
+    tmp_path: Path,
+) -> None:
+    set_sdk("openhands")
+    model = "anthropic/claude-sonnet-4-5-20250929"
+
+    from src.agent_profiles.prompt_generator.prompt_generator import (
+        make_prompt_generator_options,
+    )
+    from src.agent_profiles.prompt_proposer.prompt_proposer import (
+        make_prompt_proposer_options,
+    )
+    from src.agent_profiles.skill_generator.skill_generator import (
+        make_skill_generator_options,
+    )
+    from src.agent_profiles.skill_proposer.skill_proposer import (
+        make_skill_proposer_options,
+    )
+
+    skill_proposer = make_skill_proposer_options(project_root=tmp_path, model=model)
+    skill_generator = make_skill_generator_options(project_root=tmp_path, model=model)
+    prompt_proposer = make_prompt_proposer_options(project_root=tmp_path, model=model)
+    prompt_generator = make_prompt_generator_options(project_root=tmp_path, model=model)
+
+    _assert_openhands_options(
+        skill_proposer,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("Read", "Bash"),
+    )
+    _assert_openhands_options(
+        skill_generator,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("Read", "Write", "Edit", "Skill"),
+    )
+    _assert_openhands_options(
+        prompt_proposer,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("Read", "Bash"),
+    )
+    _assert_openhands_options(
+        prompt_generator,
+        project_root=tmp_path,
+        model=model,
+        required_tools=("Read", "Bash"),
+    )
+    assert "YAML frontmatter" in skill_generator["system"]
+    assert ".claude/skills/<skill-name>/SKILL.md" in skill_generator["system"]

--- a/tests/test_openhands_runtime.py
+++ b/tests/test_openhands_runtime.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.harness import Agent, set_sdk
+from src.schemas import AgentResponse
+
+
+@pytest.fixture(autouse=True)
+def _reset_sdk() -> None:
+    set_sdk("claude")
+    yield
+    set_sdk("claude")
+
+
+def _install_fake_openhands(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    final_message: str,
+    extracted_message: str | None = None,
+    metrics: dict | None = None,
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    class FakeTool:
+        def __init__(self, name: str):
+            self.name = name
+
+    class FakeAgentContext:
+        def __init__(self, *, skills=None, system_message_suffix=None, **_kwargs):
+            self.skills = list(skills or [])
+            self.system_message_suffix = system_message_suffix
+
+    class FakeLocalWorkspace:
+        def __init__(self, working_dir: str):
+            self.working_dir = working_dir
+
+    class FakeLLM:
+        def __init__(self, **kwargs):
+            captured["llm_init"] = kwargs
+            self.model = kwargs["model"]
+            self.metrics = SimpleNamespace(
+                get=lambda: metrics
+                or {
+                    "accumulated_cost": 0.42,
+                    "accumulated_token_usage": {"input_tokens": 10, "output_tokens": 5},
+                }
+            )
+            self.calls: list[dict] = []
+            captured["llm"] = self
+
+        def completion(self, **kwargs):
+            self.calls.append(kwargs)
+            content = extracted_message or '{"final_answer":"4","reasoning":"basic arithmetic"}'
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=content)
+                    )
+                ]
+            )
+
+    class FakeConversation:
+        def __init__(self, *, agent, workspace, callbacks=None, **kwargs):
+            captured["conversation_init"] = {
+                "agent": agent,
+                "workspace": workspace,
+                "callbacks": callbacks,
+                "kwargs": kwargs,
+            }
+            self.agent = agent
+            self.workspace = workspace
+            self.callbacks = list(callbacks or [])
+            self.messages = []
+            self.state = SimpleNamespace(events=[])
+            self.conversation_stats = SimpleNamespace(
+                usage_to_metrics={"input_tokens": 10, "output_tokens": 5}
+            )
+
+        def send_message(self, message, sender=None):
+            captured["sent_message"] = {"message": message, "sender": sender}
+
+        def run(self):
+            msg = SimpleNamespace(role="assistant", content=final_message)
+            self.messages = [msg]
+            self.state.events = [msg]
+            for callback in self.callbacks:
+                callback(msg)
+
+    def fake_get_default_agent(**kwargs):
+        captured["agent_kwargs"] = kwargs
+        return SimpleNamespace(**kwargs)
+
+    def fake_load_skills_from_dir(path):
+        captured["skills_dir"] = str(path)
+        return {}, {}, {
+            "repo-skill": SimpleNamespace(
+                name="repo-skill",
+                description="Repo-local skill",
+            )
+        }
+
+    sdk_module = SimpleNamespace(
+        LLM=FakeLLM,
+        AgentContext=FakeAgentContext,
+        LocalWorkspace=FakeLocalWorkspace,
+        Conversation=FakeConversation,
+        Tool=FakeTool,
+        get_default_agent=fake_get_default_agent,
+    )
+    monkeypatch.setitem(sys.modules, "openhands.sdk", sdk_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "openhands.sdk.context.skills",
+        SimpleNamespace(load_skills_from_dir=fake_load_skills_from_dir),
+    )
+    return captured
+
+
+def test_openhands_runtime_uses_direct_json_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    set_sdk("openhands")
+    skills_dir = tmp_path / ".claude" / "skills" / "repo-skill"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("---\nname: repo-skill\ndescription: Repo-local skill\n---\n")
+
+    captured = _install_fake_openhands(
+        monkeypatch,
+        final_message='{"final_answer":"4","reasoning":"basic arithmetic"}',
+    )
+
+    agent = Agent(
+        {
+            "sdk": "openhands",
+            "system": "Answer the question with the final answer only.",
+            "format": {
+                "type": "json_schema",
+                "schema": AgentResponse.model_json_schema(),
+            },
+            "tools": ["Read", "Edit", "Bash", "TodoWrite", "Skill"],
+            "provider_id": "anthropic",
+            "model_id": "claude-sonnet-4-5-20250929",
+            "model": "anthropic/claude-sonnet-4-5-20250929",
+            "cwd": str(tmp_path),
+            "skills_dir": str(tmp_path / ".claude" / "skills"),
+            "add_dirs": [],
+        },
+        AgentResponse,
+    )
+
+    trace = asyncio.run(agent.run("What is 2 + 2?"))
+
+    assert trace.output is not None
+    assert trace.output.final_answer == "4"
+    assert trace.output.reasoning == "basic arithmetic"
+    assert trace.result == '{"final_answer":"4","reasoning":"basic arithmetic"}'
+    assert getattr(captured["llm"], "calls") == []
+    assert captured["conversation_init"]["workspace"].working_dir == str(tmp_path)
+    assert captured["skills_dir"] == str(tmp_path / ".claude" / "skills")
+
+
+def test_openhands_runtime_falls_back_to_strict_extraction_when_final_text_is_not_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    set_sdk("openhands")
+    skills_dir = tmp_path / ".claude" / "skills" / "repo-skill"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("---\nname: repo-skill\ndescription: Repo-local skill\n---\n")
+
+    captured = _install_fake_openhands(
+        monkeypatch,
+        final_message="The final answer is 4. Reasoning: basic arithmetic.",
+    )
+
+    agent = Agent(
+        {
+            "sdk": "openhands",
+            "system": "Answer the question with the final answer only.",
+            "format": {
+                "type": "json_schema",
+                "schema": AgentResponse.model_json_schema(),
+            },
+            "tools": ["Read", "Edit", "Bash", "TodoWrite", "Skill"],
+            "provider_id": "anthropic",
+            "model_id": "claude-sonnet-4-5-20250929",
+            "model": "anthropic/claude-sonnet-4-5-20250929",
+            "cwd": str(tmp_path),
+            "skills_dir": str(tmp_path / ".claude" / "skills"),
+            "add_dirs": [],
+        },
+        AgentResponse,
+    )
+
+    trace = asyncio.run(agent.run("What is 2 + 2?"))
+
+    assert trace.output is not None
+    assert trace.output.final_answer == "4"
+    assert trace.output.reasoning == "basic arithmetic"
+    llm_calls = getattr(captured["llm"], "calls")
+    assert len(llm_calls) == 1
+    assert llm_calls[0]["response_format"]["type"] == "json_schema"
+    assert llm_calls[0]["response_format"]["json_schema"]["name"] == "AgentResponse"
+    tool_names = [tool.name for tool in captured["agent_kwargs"]["tools"]]
+    assert tool_names == ["FileEditorTool", "TerminalTool", "TaskTrackerTool"]
+    assert captured["conversation_init"]["workspace"].working_dir == str(tmp_path)

--- a/tests/test_openhands_runtime.py
+++ b/tests/test_openhands_runtime.py
@@ -105,6 +105,17 @@ def _install_fake_openhands(
             )
         }
 
+    def fake_register_default_tools(*, enable_browser=False):
+        captured["register_default_tools"] = {"enable_browser": enable_browser}
+
+    class FakeTextContent:
+        def __init__(self, text: str):
+            self.text = text
+
+    class FakeMessage:
+        def __init__(self, *, role: str, content):
+            self.role = role
+            self.content = content
     sdk_module = SimpleNamespace(
         LLM=FakeLLM,
         AgentContext=FakeAgentContext,
@@ -118,6 +129,31 @@ def _install_fake_openhands(
         sys.modules,
         "openhands.sdk.context.skills",
         SimpleNamespace(load_skills_from_dir=fake_load_skills_from_dir),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "openhands.sdk.llm",
+        SimpleNamespace(Message=FakeMessage, TextContent=FakeTextContent),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "openhands.tools",
+        SimpleNamespace(register_default_tools=fake_register_default_tools),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "openhands.tools.file_editor",
+        SimpleNamespace(FileEditorTool=SimpleNamespace(name="file_editor")),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "openhands.tools.terminal",
+        SimpleNamespace(TerminalTool=SimpleNamespace(name="terminal")),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "openhands.tools.task_tracker",
+        SimpleNamespace(TaskTrackerTool=SimpleNamespace(name="task_tracker")),
     )
     return captured
 
@@ -164,6 +200,7 @@ def test_openhands_runtime_uses_direct_json_without_fallback(
     assert getattr(captured["llm"], "calls") == []
     assert captured["conversation_init"]["workspace"].working_dir == str(tmp_path)
     assert captured["skills_dir"] == str(tmp_path / ".claude" / "skills")
+    assert captured["register_default_tools"] == {"enable_browser": False}
 
 
 def test_openhands_runtime_falls_back_to_strict_extraction_when_final_text_is_not_json(
@@ -206,8 +243,10 @@ def test_openhands_runtime_falls_back_to_strict_extraction_when_final_text_is_no
     assert trace.output.reasoning == "basic arithmetic"
     llm_calls = getattr(captured["llm"], "calls")
     assert len(llm_calls) == 1
+    assert llm_calls[0]["messages"][0].role == "system"
+    assert llm_calls[0]["messages"][1].role == "user"
     assert llm_calls[0]["response_format"]["type"] == "json_schema"
     assert llm_calls[0]["response_format"]["json_schema"]["name"] == "AgentResponse"
     tool_names = [tool.name for tool in captured["agent_kwargs"]["tools"]]
-    assert tool_names == ["FileEditorTool", "TerminalTool", "TaskTrackerTool"]
+    assert tool_names == ["file_editor", "terminal", "task_tracker"]
     assert captured["conversation_init"]["workspace"].working_dir == str(tmp_path)

--- a/tests/test_program_manager.py
+++ b/tests/test_program_manager.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.registry.manager import ProgramManager
+
+
+def test_discard_checks_out_parent_program_when_no_non_program_branch(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    manager = ProgramManager(cwd=tmp_path)
+    calls: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(manager, "_git_current_branch", lambda: "program/iter-skill-1")
+    monkeypatch.setattr(
+        manager,
+        "_git_list_branches",
+        lambda: ["program/base", "program/iter-skill-1"],
+    )
+    monkeypatch.setattr(
+        manager,
+        "_read_config_from_branch",
+        lambda branch: SimpleNamespace(parent="program/base"),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_git_checkout",
+        lambda branch: calls.append(("checkout", branch)),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_git_branch_delete",
+        lambda branch: calls.append(("delete", branch)),
+    )
+    monkeypatch.setattr(manager, "_git_list_tags", lambda: [])
+    monkeypatch.setattr(
+        manager,
+        "_git_tag_delete",
+        lambda tag: calls.append(("tag_delete", tag)),
+    )
+
+    manager.discard("iter-skill-1")
+
+    assert calls[:2] == [
+        ("checkout", "program/base"),
+        ("delete", "program/iter-skill-1"),
+    ]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -333,6 +333,25 @@ class TestOptionsToConfig:
         config = options_to_config(options, name="prog")
         assert "read" in config.allowed_tools
 
+    def test_openhands_dict_options_preserve_sdk_metadata(self):
+        from src.registry.sdk_utils import options_to_config
+
+        options = {
+            "sdk": "openhands",
+            "system": "You are helpful.",
+            "tools": ["Read", "Bash"],
+            "format": {"type": "json_schema"},
+            "provider_id": "anthropic",
+            "model_id": "claude-sonnet-4-5-20250929",
+            "model": "anthropic/claude-sonnet-4-5-20250929",
+            "cwd": "/some/path",
+            "skills_dir": "/some/path/.claude/skills",
+        }
+        config = options_to_config(options, name="my-program")
+        assert config.metadata["sdk"] == "openhands"
+        assert config.metadata["model"] == "anthropic/claude-sonnet-4-5-20250929"
+        assert config.metadata["skills_dir"] == "/some/path/.claude/skills"
+
 
 class TestConfigToOptions:
     """Test config_to_options for the opencode path (dict return)."""
@@ -374,3 +393,28 @@ class TestConfigToOptions:
         config = self._make_opencode_config()
         result = config_to_options(config, cwd="/custom/path")
         assert result["cwd"] == "/custom/path"
+
+    def test_openhands_config_returns_dict(self):
+        from src.registry.models import ProgramConfig
+        from src.registry.sdk_utils import config_to_options
+
+        config = ProgramConfig(
+            name="base",
+            system_prompt={"type": "text", "content": "You are helpful."},
+            allowed_tools=["Read", "Bash"],
+            output_format={"type": "json_schema"},
+            metadata={
+                "sdk": "openhands",
+                "provider_id": "anthropic",
+                "model_id": "claude-sonnet-4-5-20250929",
+                "model": "anthropic/claude-sonnet-4-5-20250929",
+                "skills_dir": "/tmp/.claude/skills",
+            },
+        )
+
+        result = config_to_options(config, cwd="/tmp")
+        assert isinstance(result, dict)
+        assert result["sdk"] == "openhands"
+        assert result["model"] == "anthropic/claude-sonnet-4-5-20250929"
+        assert result["skills_dir"] == "/tmp/.claude/skills"
+        assert result["tools"] == ["Read", "Bash"]

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -160,6 +160,16 @@ class TestSkillProposerResponse:
                 justification="reason",
             )
 
+    def test_edit_action_requires_target_skill(self):
+        from src.schemas import SkillProposerResponse
+
+        with pytest.raises(ValidationError, match="target_skill is required"):
+            SkillProposerResponse(
+                action="edit",
+                proposed_skill="Extend existing skill",
+                justification="Need to update current behavior",
+            )
+
     def test_missing_proposed_skill_raises(self):
         from src.schemas import SkillProposerResponse
 


### PR DESCRIPTION
Summary

Add OpenHands integration for EvoSkill
Add structured-output fallback for OpenHands runs
Recover schema-valid responses by sending the final raw answer back through LiteLLM via OpenHands with a JSON schema constraint
Validate the flow with end-to-end testing
Context

OpenHands SDK still has an active structured output issue:
https://github.com/OpenHands/software-agent-sdk/issues/2566

Until that is resolved upstream, EvoSkill uses a fallback extraction step to preserve structured handoff behavior and evaluation reliability.

Result

The fallback works correctly in practice and has been tested end to end.