### PR TITLE
feat: harbor integration for EvoSkill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,19 @@
 FROM python:3.12-slim
 
 # System deps
+ARG NODE_MAJOR=20
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         curl \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
+        ca-certificates \
+        gnupg \
+        libgomp1 \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+       | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+       > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # CLI tools for harnesses that need external binaries
@@ -27,16 +35,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 #   goose    — tarball from GitHub releases (goose harness spawns this)
 RUN npm install -g @anthropic-ai/claude-code opencode-ai @openai/codex && npm cache clean --force
 
+ARG GOOSE_VERSION=v1.33.1
 RUN ARCH=$(uname -m) && \
-    GOOSE_VER=$(curl -sL "https://api.github.com/repos/block/goose/releases/latest" \
-      | grep -m1 '"tag_name"' | cut -d'"' -f4) && \
-    if [ -z "$GOOSE_VER" ]; then \
-      GOOSE_VER=$(curl -sL "https://api.github.com/repos/block/goose/releases" \
-        | grep -m1 '"tag_name"' | cut -d'"' -f4); \
-    fi && \
-    echo "Installing goose ${GOOSE_VER} for ${ARCH}" && \
-    curl -fsSL "https://github.com/block/goose/releases/download/${GOOSE_VER}/goose-${ARCH}-unknown-linux-gnu.tar.gz" \
-    | tar xz -C /usr/local/bin/
+    echo "Installing goose ${GOOSE_VERSION} for ${ARCH}" && \
+    curl --http1.1 -fSL --retry 5 --retry-delay 10 \
+      -o /tmp/goose.tar.gz \
+      "https://github.com/block/goose/releases/download/${GOOSE_VERSION}/goose-${ARCH}-unknown-linux-gnu.tar.gz" && \
+    tar xz -C /usr/local/bin/ -f /tmp/goose.tar.gz && \
+    rm /tmp/goose.tar.gz
 
 # Python deps — core + all harness SDKs.
 # Excludes packages not imported at runtime (torch, datasets, notebook, plotly, etc.)
@@ -59,9 +65,15 @@ RUN pip install --no-cache-dir \
     "daytona>=0.1.0" \
     "harbor>=0.6.0"
 
+# Non-root user
+RUN useradd -m -s /bin/bash evoskill \
+    && mkdir -p /workspace && chown evoskill:evoskill /workspace
+
 # Git config for bundle operations
 RUN git config --global user.email "evoskill@sandbox" \
     && git config --global user.name "EvoSkill Sandbox" \
     && git config --global init.defaultBranch main
 
 WORKDIR /workspace
+USER evoskill
+ENV PATH="/home/evoskill/.local/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # EvoSkill container image.
 #
-# Supports all harnesses: Claude, OpenCode, Codex, Goose, OpenHands.
+# Supports all harnesses: Claude, OpenCode, Codex, Goose, OpenHands, Harbor.
 #
 # Local (BYOC):
 #   docker build -t evoskill .
@@ -56,7 +56,8 @@ RUN pip install --no-cache-dir \
     "tqdm>=4.60.0" \
     "httpx>=0.23.0" \
     "hatchling" \
-    "daytona>=0.1.0"
+    "daytona>=0.1.0" \
+    "harbor>=0.6.0"
 
 # Git config for bundle operations
 RUN git config --global user.email "evoskill@sandbox" \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/sentient-agi/EvoSkill/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache 2.0-007ec6?style=for-the-badge" alt="License: Apache 2.0"></a>
 </p>
 
-<b>Turn your general AI agents into state-of-the-art specialists with a benchmark and EvoSkill, a toolkit for automatically creating and improving AI skills, compatible with Claude Code, Codex CLI, OpenCode, OpenHands, Goose, and more.</b>
+<b>Turn your general AI agents into state-of-the-art specialists with a benchmark and EvoSkill, a toolkit for automatically creating and improving AI skills, compatible with Claude Code, Codex CLI, OpenCode, OpenHands, Goose, Harbor, and more.</b>
 
 <b>EvoSkill</b> significantly extends the feedback-driven idea of <b>[GEPA](https://github.com/sentient-agi/gepa-plus)</b> from single-file optimization to complete agent evolution. Instead of only revising one prompt in place like GEPA, EvoSkill proposes multiple skill and prompt mutations jointly, evaluates new variants on held-out data, and has each iteration produce an entirely new agent program.
 
@@ -60,6 +60,11 @@ Also join us on [Discord](https://discord.gg/sentientfoundation) to discuss your
       <td><a href="https://openai.com/index/introducing-codex/">Codex CLI</a></td>
       <td>✅</td>
       <td>Skill discovery via .agents/skills/ symlink</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/harbor-framework/harbor">Harbor</a></td>
+      <td>✅</td>
+      <td>Containerized task benchmarks with built-in verifiers</td>
     </tr>
   </tbody>
 </table>   
@@ -124,6 +129,7 @@ Also join us on [Discord](https://discord.gg/sentientfoundation) to discuss your
 
 - [Installation](#installation)
 - [Quickstart](#quickstart)
+- [Harbor Integration](#harbor-integration)
 - [CLI Reference](#cli-reference)
 - [Configuration Reference](#configuration-reference)
 - [How It Works](#how-it-works)
@@ -155,6 +161,7 @@ brew install --cask claude-code    # Claude Code
 brew install opencode              # OpenCode (v1.4.0+)
 brew install --cask codex          # Codex CLI
 brew install block-goose-cli       # Goose (v1.25.0+)
+pip install harbor                 # Harbor (containerized benchmarks)
 ```
 
 **Common auth setup:**
@@ -180,12 +187,15 @@ OpenRouter-backed evolution runs also accept `LLM_API_KEY`, but `OPENROUTER_API_
 
 Run `evoskill init` inside any git repository:
 
+**CSV dataset (question/answer pairs):**
+
 ```bash
 $ evoskill init
 
   EvoSkill — Project Setup
 
   Which agent runtime? › claude
+  Dataset source? › CSV
   Absolute path to dataset CSV? › /path/to/questions.csv
   Question/input column name? › question
   Answer column name? › answer
@@ -194,10 +204,24 @@ $ evoskill init
   How do you want to run EvoSkill? › Local
 ```
 
+**Harbor dataset (containerized benchmark tasks):**
+
+```bash
+$ evoskill init
+
+  EvoSkill — Project Setup
+
+  Which agent runtime? › claude
+  Dataset source? › Harbor
+  Choose a Harbor dataset: › swe-bench/swe-bench-verified
+  Where to store this dataset? › .evoskill/harbor/datasets/swe-bench-verified
+  How do you want to run EvoSkill? › Local
+```
+
 This creates `.evoskill/config.toml` and `.evoskill/task.md`.
 
-- **Dataset path** — absolute path to your CSV with questions and ground-truth answers.
-- **Data dirs** — absolute paths to directories the agent needs (e.g. reference documents). Comma-separated if multiple.
+- **Dataset source** — CSV (static question/answer pairs) or Harbor (containerized tasks with built-in verifiers).
+- **Data dirs** — (CSV only) absolute paths to directories the agent needs. Comma-separated if multiple.
 - **Execution mode** — Local (direct), Docker (containerized, supports remote via `DOCKER_HOST`), or Daytona (managed cloud sandbox).
 
 ### 2. Describe your task
@@ -264,6 +288,75 @@ ls .claude/skills/             # all learned skills
 ```
 
 Copy `.claude/program.yaml` and `.claude/skills/` into your deployment to use the evolved agent configuration.
+
+## Harbor Integration
+
+[Harbor](https://github.com/harbor-framework/harbor) is a framework for evaluating AI agents against containerized benchmark tasks. EvoSkill integrates with Harbor as an alternative to CSV-based datasets, using Harbor's built-in verifiers as the scoring mechanism.
+
+### How it works
+
+Instead of running agents against static CSV questions, Harbor mode:
+
+1. **Loads tasks** from a downloaded Harbor dataset (each task has its own Dockerfile, test harness, and verifier)
+2. **Runs `harbor run`** for each task, spawning a sandboxed container where the coding agent solves the task
+3. **Reads the verifier reward** from the container output (0.0 to 1.0)
+4. **Feeds results** back into EvoSkill's self-improvement loop to evolve better skills
+
+### Setup
+
+```bash
+pip install harbor    # install the Harbor CLI
+```
+
+Run `evoskill init` and select **Harbor** as the dataset source. Init will show available datasets from the [Harbor Hub](https://hub.harborframework.com/datasets) and auto-download your selection.
+
+### Configuration
+
+When Harbor is selected during init, the following config is auto-generated:
+
+```toml
+[dataset]
+source = "harbor"
+harbor_tasks_root = ".evoskill/harbor/datasets/swe-bench-verified"
+train_ratio = 0.18
+val_ratio = 0.12
+
+[harbor]
+enabled = true
+inner_agent = "claude-code"      # auto-derived from harness.name
+inner_model = "anthropic/claude-sonnet-4-6"  # auto-derived from harness.model
+env = "docker"                   # "docker" for local, "daytona" for remote
+n_concurrent = 1
+timeout_multiplier = 1.0
+container_skills_path = "/skills"
+
+[scorer]
+type = "harbor"
+```
+
+The `inner_agent` and `inner_model` are automatically derived from your harness selection. The `env` is derived from your execution mode (`docker` for local/Docker, `daytona` for Daytona).
+
+### Filtering tasks
+
+You can filter which tasks are included using glob patterns:
+
+```toml
+[dataset]
+harbor_include = ["swe-bench/*"]     # only include matching tasks
+harbor_exclude = ["swe-bench/hard*"] # exclude matching tasks
+harbor_difficulty = ["easy", "medium"]  # filter by difficulty metadata
+harbor_limit = 50                    # max number of tasks
+```
+
+### Execution modes
+
+| Mode | How Harbor runs tasks | Notes |
+|------|----------------------|-------|
+| Local | `harbor run -e docker` | Requires Docker installed locally |
+| Docker | `harbor run -e docker` | Harbor tasks dir mounted as volume |
+| Daytona | `harbor run -e daytona` | Harbor uses Daytona API to create task sandboxes. `DAYTONA_API_KEY` is forwarded automatically. |
+
+> **Note:** When running on Daytona, EvoSkill automatically overrides `harbor.env` to `"daytona"` since Docker is not available inside Daytona sandboxes.
 
 ## CLI Reference
 
@@ -408,6 +501,7 @@ Notes:
 | `exact` | Case-insensitive exact string match |
 | `llm` | LLM-as-judge grading with a custom rubric |
 | `script` | Shell script scorer — receives `{predicted}` and `{expected}` as variables |
+| `harbor` | Reads reward from Harbor's built-in verifier (auto-set when dataset source is Harbor) |
 
 **LLM scorer options:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "tomli-w>=1.2.0",
     "hatchling",
     "daytona>=0.1.0",
+    "harbor>=0.6.1",
 ]
 
 [project.scripts]

--- a/src/api/harbor_loader.py
+++ b/src/api/harbor_loader.py
@@ -106,15 +106,24 @@ def load_harbor_tasks(cfg) -> pd.DataFrame:
     Side effect: populates the module-level TASK_PATH_INDEX so HarborAgent can
     resolve a task id back to its on-disk digest directory.
     """
-    root_str = cfg.dataset.harbor_tasks_root
-    if not root_str:
+    # Use the property which handles docker/daytona path overrides.
+    try:
+        root = cfg.harbor_tasks_root_path
+    except AttributeError:
+        # Fallback for tests or plain config dicts without the property.
+        root_str = cfg.dataset.harbor_tasks_root
+        if not root_str:
+            raise HarborLoadError(
+                "dataset.harbor_tasks_root must be set when dataset.source = 'harbor'"
+            )
+        root = Path(root_str).expanduser()
+        if not root.is_absolute():
+            root = (cfg.project_root / root).resolve()
+
+    if not str(root) or str(root) == '.':
         raise HarborLoadError(
             "dataset.harbor_tasks_root must be set when dataset.source = 'harbor'"
         )
-
-    root = Path(root_str).expanduser()
-    if not root.is_absolute():
-        root = (cfg.project_root / root).resolve()
 
     tasks = _iter_task_dirs(root)
     if not tasks:

--- a/src/api/harbor_loader.py
+++ b/src/api/harbor_loader.py
@@ -1,0 +1,158 @@
+"""Load a downloaded Harbor task directory as an EvoSkill dataset.
+
+Harbor's `harbor download <dataset>` produces a tree like:
+
+    <root>/<org>/<task_name>/<digest>/
+        task.toml
+        instruction.md
+        environment/Dockerfile
+        tests/{test.sh,verify.py,expected.json,config.json}
+
+EvoSkill's loop expects (question, ground_truth, category) triples. We turn each
+discovered task into:
+
+    question     -> "<org>/<task_name>"  (Harbor-relative task id)
+    ground_truth -> "1.0"                (sentinel; Harbor's verifier is the truth)
+    category     -> task.toml [metadata].category, or "default"
+
+The HarborAgent later turns the question (task id) into a `harbor run -p <digest_dir>`
+invocation. The harbor scorer reads the agent's reward back from a JSON envelope.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+# Internal envelope used to map task id -> resolved digest dir without polluting
+# the downstream tuple shape. `task_paths` is read by HarborAgent.
+TASK_PATH_INDEX: dict[str, Path] = {}
+
+
+@dataclass
+class _HarborTask:
+    task_id: str          # "arcprize/0934a4d8_0"
+    task_dir: Path        # the digest dir containing task.toml
+    category: str
+    difficulty: str       # "easy" / "medium" / "hard" / "default" if absent
+
+
+class HarborLoadError(RuntimeError):
+    pass
+
+
+def _iter_task_dirs(root: Path) -> list[_HarborTask]:
+    """Walk <root>/<org>/<name>/<digest>/ looking for task.toml.
+
+    A task.toml at depth 3 from root identifies a real task root. Other depths
+    are tolerated so the loader still works if Harbor changes its layout.
+    """
+    found: list[_HarborTask] = []
+    if not root.is_dir():
+        raise HarborLoadError(f"harbor_tasks_root does not exist: {root}")
+
+    for toml_path in root.rglob("task.toml"):
+        task_dir = toml_path.parent
+        try:
+            data = tomllib.loads(toml_path.read_text())
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            raise HarborLoadError(f"failed to read {toml_path}: {exc}") from exc
+
+        # Pull task id from [task].name first, fall back to dir layout.
+        task_section = data.get("task") or {}
+        task_id = task_section.get("name")
+        if not task_id:
+            # Fallback: <root>/<org>/<name>/<digest> -> "<org>/<name>"
+            try:
+                rel = task_dir.relative_to(root)
+                parts = rel.parts
+                if len(parts) >= 2:
+                    task_id = f"{parts[0]}/{parts[1]}"
+            except ValueError:
+                pass
+        if not task_id:
+            continue
+
+        metadata = data.get("metadata") or {}
+        category = str(metadata.get("category") or "default")
+        difficulty = str(metadata.get("difficulty") or "default")
+
+        found.append(
+            _HarborTask(
+                task_id=task_id,
+                task_dir=task_dir,
+                category=category,
+                difficulty=difficulty,
+            )
+        )
+
+    return found
+
+
+def _matches_any(task_id: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(task_id, p) for p in patterns)
+
+
+def load_harbor_tasks(cfg) -> pd.DataFrame:
+    """Return a DataFrame with columns (question, ground_truth, category).
+
+    `cfg` is a ProjectConfig. Reads cfg.dataset.harbor_tasks_root, harbor_limit,
+    harbor_include, harbor_exclude.
+
+    Side effect: populates the module-level TASK_PATH_INDEX so HarborAgent can
+    resolve a task id back to its on-disk digest directory.
+    """
+    root_str = cfg.dataset.harbor_tasks_root
+    if not root_str:
+        raise HarborLoadError(
+            "dataset.harbor_tasks_root must be set when dataset.source = 'harbor'"
+        )
+
+    root = Path(root_str).expanduser()
+    if not root.is_absolute():
+        root = (cfg.project_root / root).resolve()
+
+    tasks = _iter_task_dirs(root)
+    if not tasks:
+        raise HarborLoadError(f"no task.toml files found under {root}")
+
+    include = cfg.dataset.harbor_include or []
+    exclude = cfg.dataset.harbor_exclude or []
+    difficulties = cfg.dataset.harbor_difficulty or []
+    if include:
+        tasks = [t for t in tasks if _matches_any(t.task_id, include)]
+    if exclude:
+        tasks = [t for t in tasks if not _matches_any(t.task_id, exclude)]
+    if difficulties:
+        tasks = [t for t in tasks if t.difficulty in difficulties]
+
+    # Stable order by task id so train/val splits are reproducible across runs.
+    tasks.sort(key=lambda t: t.task_id)
+
+    if cfg.dataset.harbor_limit:
+        tasks = tasks[: cfg.dataset.harbor_limit]
+
+    if not tasks:
+        raise HarborLoadError("harbor task filters left no tasks to run")
+
+    # Refresh the global path index for HarborAgent.
+    TASK_PATH_INDEX.clear()
+    for t in tasks:
+        TASK_PATH_INDEX[t.task_id] = t.task_dir
+
+    return pd.DataFrame(
+        {
+            "question": [t.task_id for t in tasks],
+            "ground_truth": ["1.0"] * len(tasks),
+            "category": [t.category for t in tasks],
+        }
+    )
+
+
+def resolve_task_dir(task_id: str) -> Path | None:
+    """Look up a task id's digest dir. Returns None if unknown."""
+    return TASK_PATH_INDEX.get(task_id)

--- a/src/cli/commands/eval.py
+++ b/src/cli/commands/eval.py
@@ -26,6 +26,21 @@ def eval_cmd(verbose: bool, config_path: Path | None):
     from src.registry import ProgramManager
     from src.schemas import AgentResponse
     cfg = load_config(config_path=config_path)
+
+    # Validate harbor + dataset coherence
+    if cfg.harbor.enabled and cfg.dataset.source != "harbor":
+        console.print(
+            "[red]Error:[/red] harbor.enabled is true but dataset.source is "
+            f"'{cfg.dataset.source}'. Set dataset.source = \"harbor\" in config.toml."
+        )
+        raise SystemExit(1)
+    if cfg.dataset.source == "harbor" and not cfg.harbor.enabled:
+        console.print(
+            "[red]Error:[/red] dataset.source is 'harbor' but harbor.enabled is false. "
+            "Set harbor.enabled = true in config.toml."
+        )
+        raise SystemExit(1)
+
     sdk = cfg.harness.name
     set_sdk(sdk)
 

--- a/src/cli/commands/eval.py
+++ b/src/cli/commands/eval.py
@@ -38,6 +38,11 @@ def eval_cmd(verbose: bool, config_path: Path | None):
     except FileNotFoundError:
         console.print(f'[red]Error:[/red] Dataset not found at {cfg.dataset_path}')
         raise SystemExit(1)
+    except Exception as exc:
+        if exc.__class__.__name__ == "HarborLoadError":
+            console.print(f'[red]Error:[/red] Harbor dataset: {exc}')
+            raise SystemExit(1)
+        raise
 
     manager = ProgramManager(cwd=cfg.project_root)
     best = manager.get_best_from_frontier()
@@ -49,16 +54,33 @@ def eval_cmd(verbose: bool, config_path: Path | None):
 
     console.print(f'\n  Evaluating [bold]{best}[/bold] on {len(val_data)} samples...\n')
 
-    agent = Agent(
-        make_base_agent_options(
-            model=cfg.harness.model,
-            data_dirs=cfg.harness.data_dirs,
+    if cfg.harbor.enabled:
+        from src.harness.harbor import HarborAgent
+        agent = HarborAgent(
             project_root=cfg.project_root,
-        ),
-        AgentResponse,
-        timeout_seconds=cfg.harness.timeout_seconds,
-        max_retries=cfg.harness.max_retries,
-    )
+            skills_source_dir=cfg.project_root / '.claude' / 'skills',
+            inner_agent=cfg.harbor.inner_agent,
+            inner_model=cfg.harbor.inner_model,
+            env=cfg.harbor.env,
+            n_concurrent=cfg.harbor.n_concurrent,
+            timeout_seconds=cfg.harness.timeout_seconds,
+            max_retries=cfg.harness.max_retries,
+            jobs_dir=Path(cfg.harbor.jobs_dir) if cfg.harbor.jobs_dir else None,
+            container_skills_path=cfg.harbor.container_skills_path,
+            timeout_multiplier=cfg.harbor.timeout_multiplier,
+            extra_args=cfg.harbor.extra_args,
+        )
+    else:
+        agent = Agent(
+            make_base_agent_options(
+                model=cfg.harness.model,
+                data_dirs=cfg.harness.data_dirs,
+                project_root=cfg.project_root,
+            ),
+            AgentResponse,
+            timeout_seconds=cfg.harness.timeout_seconds,
+            max_retries=cfg.harness.max_retries,
+        )
     scorer = make_scorer(cfg)
 
     qa_data = [(q, a) for q, a, _ in val_data]

--- a/src/cli/commands/init.py
+++ b/src/cli/commands/init.py
@@ -545,6 +545,9 @@ def init_cmd():
 
     remote_config = None
     if exec_mode == 'daytona':
+        click.echo('\n  Note: Daytona uploads all data to a remote sandbox. Large datasets')
+        click.echo('  or data directories (>1GB compressed) may fail to upload.')
+        click.echo('  If uploads fail, try Docker or local mode instead.\n')
         import os
         env_key = os.environ.get('DAYTONA_API_KEY', '')
         api_key_input = questionary.text(

--- a/src/cli/commands/init.py
+++ b/src/cli/commands/init.py
@@ -42,7 +42,7 @@ DEFAULT_CONFIG = {
         'category_column': '',
         'train_ratio': 0.18,
         'val_ratio': 0.12,
-        'harbor_tasks_root': '.evoskill/harbor/datasets',
+        'harbor_tasks_root': '',
         'harbor_limit': None,
         'harbor_include': [],
         'harbor_exclude': [],
@@ -413,7 +413,7 @@ def _load_prompt_defaults(config_path: Path) -> dict[str, str]:
         'gt_col': DEFAULT_CONFIG['dataset']['ground_truth_column'],
         'category_col': 'category',
         'data_dirs_raw': '',
-        'harbor_tasks_root': '.evoskill/harbor/datasets',
+        'harbor_tasks_root': '',
     }
     if not config_path.exists():
         return defaults
@@ -502,9 +502,12 @@ def init_cmd():
                 validate=_require_non_empty,
             ).ask()
 
+        # Build dataset-specific subfolder: "swe-bench/swe-bench-verified" → "swe-bench-verified"
+        dataset_slug = harbor_dataset_name.split('/')[-1] if '/' in harbor_dataset_name else harbor_dataset_name
+        default_root = f'.evoskill/harbor/datasets/{dataset_slug}'
         harbor_tasks_root = questionary.text(
-            'Where to store Harbor tasks?',
-            default=prompt_defaults['harbor_tasks_root'],
+            'Where to store this dataset?',
+            default=default_root,
             validate=_require_non_empty,
         ).ask()
     else:

--- a/src/cli/commands/init.py
+++ b/src/cli/commands/init.py
@@ -9,6 +9,15 @@ import click
 from src.harness.model_aliases import default_model_for_harness
 
 EVOSKILL_DIR = '.evoskill'
+
+# Map EvoSkill harness names to Harbor's agent identifiers.
+_HARNESS_TO_HARBOR_AGENT: dict[str, str] = {
+    'claude': 'claude-code',
+    'opencode': 'opencode',
+    'codex': 'codex',
+    'goose': 'goose',
+    'openhands': 'openhands',
+}
 DEFAULT_CONFIG = {
     'harness': {
         'name': 'claude',
@@ -26,14 +35,32 @@ DEFAULT_CONFIG = {
         'failure_samples': 3,
     },
     'dataset': {
+        'source': 'csv',
         'path': '/absolute/path/to/questions.csv',
         'question_column': 'question',
         'ground_truth_column': 'ground_truth',
+        'category_column': '',
         'train_ratio': 0.18,
         'val_ratio': 0.12,
+        'harbor_tasks_root': '.evoskill/harbor/datasets',
+        'harbor_limit': None,
+        'harbor_include': [],
+        'harbor_exclude': [],
+        'harbor_difficulty': [],
     },
     'scorer': {
         'type': 'multi_tolerance',
+    },
+    'harbor': {
+        'enabled': False,
+        'inner_agent': 'claude-code',
+        'inner_model': 'anthropic/claude-sonnet-4-5',
+        'env': 'docker',
+        'n_concurrent': 1,
+        'timeout_multiplier': 1.0,
+        'jobs_dir': '',
+        'container_skills_path': '/skills',
+        'extra_args': [],
     },
 }
 
@@ -50,6 +77,120 @@ TASK_MD_TEMPLATE = (
     '- Must answers include units? → yes\n'
     '- Should the agent use external APIs? → no\n'
 )
+
+
+PAGE_SIZE = 5
+_REGISTRY_URL = 'https://raw.githubusercontent.com/laude-institute/harbor/main/registry.json'
+_CACHE_MAX_AGE_DAYS = 30
+
+
+def _harbor_cli_available() -> bool:
+    """Check if the harbor CLI is on PATH."""
+    import shutil
+    return shutil.which('harbor') is not None
+
+
+def _registry_cache_path() -> Path:
+    return Path(EVOSKILL_DIR) / 'harbor' / 'registry_cache.json'
+
+
+def _fetch_harbor_datasets(cwd: Path) -> list[dict]:
+    """Fetch the Harbor registry, using a local 30-day cache."""
+    import time
+    import urllib.request
+
+    cache_path = cwd / _registry_cache_path()
+
+    # Use cache if fresh
+    if cache_path.exists():
+        age_days = (time.time() - cache_path.stat().st_mtime) / 86400
+        if age_days < _CACHE_MAX_AGE_DAYS:
+            try:
+                return json.loads(cache_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    # Fetch from GitHub
+    try:
+        with urllib.request.urlopen(_REGISTRY_URL, timeout=15) as resp:
+            data = json.loads(resp.read().decode())
+    except Exception:
+        # Fall back to stale cache if fetch fails
+        if cache_path.exists():
+            try:
+                return json.loads(cache_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                pass
+        return []
+
+    # Cache it
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(data, indent=2))
+    return data
+
+
+def _list_harbor_datasets(cwd: Path) -> list[str]:
+    """Return sorted dataset names (org/name) from the Harbor registry."""
+    entries = _fetch_harbor_datasets(cwd)
+    seen: set[str] = set()
+    names: list[str] = []
+    for entry in entries:
+        name = entry.get('name', '')
+        if name and name not in seen:
+            seen.add(name)
+            names.append(name)
+    names.sort()
+    return names
+
+
+def _pick_harbor_dataset(datasets: list[str]) -> str | None:
+    """Paginated dataset picker. Returns chosen dataset name or None on abort."""
+    import questionary
+
+    offset = 0
+    while True:
+        page = datasets[offset:offset + PAGE_SIZE]
+        has_more = offset + PAGE_SIZE < len(datasets)
+
+        choices = [questionary.Choice(ds, value=ds) for ds in page]
+        if has_more:
+            choices.append(questionary.Choice('  ↓ Show more...', value='__more__'))
+        choices.append(questionary.Choice('  ✎ Type a dataset name manually', value='__manual__'))
+
+        picked = questionary.select(
+            f'Choose a Harbor dataset ({offset + 1}-{offset + len(page)} of {len(datasets)}):',
+            choices=choices,
+        ).ask()
+
+        if picked is None:
+            return None
+        if picked == '__more__':
+            offset += PAGE_SIZE
+            continue
+        if picked == '__manual__':
+            return questionary.text(
+                'Dataset name (e.g. swe-bench/swe-bench-verified):',
+                validate=_require_non_empty,
+            ).ask()
+        return picked
+
+
+def _download_harbor_dataset(dataset_name: str, output_dir: Path) -> bool:
+    """Run `harbor datasets download <name> -o <dir>`. Returns True on success."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    click.echo(f'\n  Downloading {dataset_name} into {output_dir} ...')
+    try:
+        result = subprocess.run(
+            ['harbor', 'datasets', 'download', dataset_name, '-o', str(output_dir)],
+            timeout=600,
+        )
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        click.echo('  Download timed out (10 min limit).')
+        return False
+    except FileNotFoundError:
+        click.echo('  harbor CLI not found.')
+        return False
 
 
 def _require_non_empty(value: str) -> bool | str:
@@ -120,26 +261,75 @@ def _render_config(config: dict) -> str:
     _append_toml_field(lines, 'Stop after this many iterations with no improvement.', 'no_improvement_limit', config['evolution']['no_improvement_limit'])
     lines.append('')
     _append_toml_field(lines, 'How many failing examples to sample when proposing changes.', 'failure_samples', config['evolution']['failure_samples'])
+    ds = config['dataset']
     lines.extend([
         '',
         '[dataset]',
     ])
-    _append_toml_field(lines, 'Absolute path to the dataset CSV.', 'path', config['dataset']['path'])
+    _append_toml_field(lines, 'Dataset source: "csv" or "harbor".', 'source', ds['source'])
     lines.append('')
-    _append_toml_field(lines, 'CSV column containing the question or task input.', 'question_column', config['dataset']['question_column'])
-    lines.append('')
-    _append_toml_field(lines, 'CSV column containing the expected answer.', 'ground_truth_column', config['dataset']['ground_truth_column'])
-    lines.append('')
-    _append_toml_field(lines, 'CSV column used to group or stratify examples.', 'category_column', config['dataset']['category_column'])
-    lines.append('')
-    _append_toml_field(lines, 'Fraction of each category used for training samples.', 'train_ratio', config['dataset']['train_ratio'])
-    lines.append('')
-    _append_toml_field(lines, 'Fraction of each category used for validation samples.', 'val_ratio', config['dataset']['val_ratio'])
+
+    if ds['source'] == 'harbor':
+        _append_toml_field(lines, 'Path to downloaded Harbor tasks directory.', 'harbor_tasks_root', ds['harbor_tasks_root'])
+        lines.append('')
+        _append_toml_field(lines, 'Fraction of tasks used for training.', 'train_ratio', ds['train_ratio'])
+        lines.append('')
+        _append_toml_field(lines, 'Fraction of tasks used for validation.', 'val_ratio', ds['val_ratio'])
+        if ds.get('harbor_limit') is not None:
+            lines.append('')
+            _append_toml_field(lines, 'Maximum number of tasks to include.', 'harbor_limit', ds['harbor_limit'])
+        if ds.get('harbor_include'):
+            lines.append('')
+            _append_toml_list_field(lines, 'Glob patterns to include (e.g. "arcprize/*").', 'harbor_include', ds['harbor_include'])
+        if ds.get('harbor_exclude'):
+            lines.append('')
+            _append_toml_list_field(lines, 'Glob patterns to exclude.', 'harbor_exclude', ds['harbor_exclude'])
+        if ds.get('harbor_difficulty'):
+            lines.append('')
+            _append_toml_list_field(lines, 'Filter by difficulty (e.g. "easy", "medium", "hard").', 'harbor_difficulty', ds['harbor_difficulty'])
+    else:
+        _append_toml_field(lines, 'Absolute path to the dataset CSV.', 'path', ds['path'])
+        lines.append('')
+        _append_toml_field(lines, 'CSV column containing the question or task input.', 'question_column', ds['question_column'])
+        lines.append('')
+        _append_toml_field(lines, 'CSV column containing the expected answer.', 'ground_truth_column', ds['ground_truth_column'])
+        lines.append('')
+        if ds.get('category_column'):
+            _append_toml_field(lines, 'CSV column used to group or stratify examples.', 'category_column', ds['category_column'])
+            lines.append('')
+        _append_toml_field(lines, 'Fraction of each category used for training samples.', 'train_ratio', ds['train_ratio'])
+        lines.append('')
+        _append_toml_field(lines, 'Fraction of each category used for validation samples.', 'val_ratio', ds['val_ratio'])
+
     lines.extend([
         '',
         '[scorer]',
     ])
     _append_toml_field(lines, 'Scoring rule used to compare predictions against ground truth.', 'type', config['scorer']['type'])
+
+    # Harbor section (only when enabled)
+    hc = config.get('harbor', {})
+    if hc.get('enabled'):
+        lines.extend(['', '', '[harbor]'])
+        _append_toml_field(lines, 'Enable Harbor sandbox execution for the base agent.', 'enabled', True)
+        lines.append('')
+        _append_toml_field(lines, 'Agent running inside Harbor containers.', 'inner_agent', hc['inner_agent'])
+        lines.append('')
+        _append_toml_field(lines, 'Model for the inner agent.', 'inner_model', hc['inner_model'])
+        lines.append('')
+        _append_toml_field(lines, 'Container environment: docker, daytona, modal, e2b, runloop.', 'env', hc['env'])
+        lines.append('')
+        _append_toml_field(lines, 'Parallel trials per harbor invocation.', 'n_concurrent', hc['n_concurrent'])
+        lines.append('')
+        _append_toml_field(lines, 'Multiply the task timeout by this factor.', 'timeout_multiplier', hc['timeout_multiplier'])
+        if hc.get('jobs_dir'):
+            lines.append('')
+            _append_toml_field(lines, 'Directory for Harbor job output.', 'jobs_dir', hc['jobs_dir'])
+        lines.append('')
+        _append_toml_field(lines, 'Path inside container where evolved skills are mounted.', 'container_skills_path', hc['container_skills_path'])
+        if hc.get('extra_args'):
+            lines.append('')
+            _append_toml_list_field(lines, 'Additional arguments passed to harbor run.', 'extra_args', hc['extra_args'])
 
     if 'remote' in config and config['remote']:
         rc = config['remote']
@@ -186,10 +376,25 @@ def _write_config(path: Path, answers: dict) -> None:
     config['harness']['model'] = default_model_for_harness(answers['harness'])
     config['harness']['data_dirs'] = answers['data_dirs']
     config['evolution']['mode'] = answers.get('mode', DEFAULT_CONFIG['evolution']['mode'])
-    config['dataset']['path'] = answers['dataset_path']
-    config['dataset']['question_column'] = answers['question_col']
-    config['dataset']['ground_truth_column'] = answers['gt_col']
-    config['dataset']['category_column'] = answers['category_col']
+
+    dataset_source = answers.get('dataset_source', 'csv')
+    config['dataset']['source'] = dataset_source
+
+    if dataset_source == 'harbor':
+        config['dataset']['harbor_tasks_root'] = answers['harbor_tasks_root']
+        config['scorer']['type'] = 'harbor'
+        config['harbor'] = dict(DEFAULT_CONFIG['harbor'])
+        config['harbor']['enabled'] = True
+        harness_name = answers['harness']
+        config['harbor']['inner_agent'] = _HARNESS_TO_HARBOR_AGENT.get(harness_name, harness_name)
+        config['harbor']['inner_model'] = config['harness']['model']
+        exec_mode = answers.get('execution', 'local')
+        config['harbor']['env'] = 'daytona' if exec_mode == 'daytona' else 'docker'
+    else:
+        config['dataset']['path'] = answers['dataset_path']
+        config['dataset']['question_column'] = answers['question_col']
+        config['dataset']['ground_truth_column'] = answers['gt_col']
+        config['dataset']['category_column'] = answers['category_col']
 
     if answers.get('execution', 'local') != 'local':
         config['execution'] = answers['execution']
@@ -202,11 +407,13 @@ def _write_config(path: Path, answers: dict) -> None:
 def _load_prompt_defaults(config_path: Path) -> dict[str, str]:
     defaults = {
         'harness': DEFAULT_CONFIG['harness']['name'],
+        'dataset_source': 'csv',
         'dataset_path': DEFAULT_CONFIG['dataset']['path'],
         'question_col': DEFAULT_CONFIG['dataset']['question_column'],
         'gt_col': DEFAULT_CONFIG['dataset']['ground_truth_column'],
         'category_col': 'category',
         'data_dirs_raw': '',
+        'harbor_tasks_root': '.evoskill/harbor/datasets',
     }
     if not config_path.exists():
         return defaults
@@ -218,11 +425,13 @@ def _load_prompt_defaults(config_path: Path) -> dict[str, str]:
     dataset = raw.get('dataset', {})
 
     defaults['harness'] = harness.get('name', defaults['harness'])
+    defaults['dataset_source'] = dataset.get('source', defaults['dataset_source'])
     defaults['dataset_path'] = dataset.get('path', defaults['dataset_path'])
     defaults['question_col'] = dataset.get('question_column', defaults['question_col'])
     defaults['gt_col'] = dataset.get('ground_truth_column', defaults['gt_col'])
     defaults['category_col'] = dataset.get('category_column', defaults['category_col']) or defaults['category_col']
     defaults['data_dirs_raw'] = ','.join(harness.get('data_dirs', []))
+    defaults['harbor_tasks_root'] = dataset.get('harbor_tasks_root', defaults['harbor_tasks_root'])
     return defaults
 
 
@@ -258,30 +467,70 @@ def init_cmd():
         click.echo('\n  Note: OpenHands uses fallback JSON extraction for structured output.')
         click.echo('  Consider Claude, OpenCode, or Goose for more reliable results.\n')
 
-    # 2. Dataset
-    dataset_path = questionary.text(
-        'Absolute path to dataset CSV?',
-        default=prompt_defaults['dataset_path'],
-        validate=_require_non_empty,
+    # 2. Dataset source
+    dataset_source = questionary.select(
+        'Dataset source?',
+        choices=[
+            questionary.Choice('CSV — static question/answer pairs from a CSV file', value='csv'),
+            questionary.Choice('Harbor — containerized tasks from a Harbor dataset', value='harbor'),
+        ],
+        default=prompt_defaults['dataset_source'],
     ).ask()
-    question_col = questionary.text(
-        'Question/input column name?',
-        default=prompt_defaults['question_col'],
-        validate=_require_non_empty,
-    ).ask()
-    gt_col = questionary.text(
-        'Answer column name?',
-        default=prompt_defaults['gt_col'],
-        validate=_require_non_empty,
-    ).ask()
-    category_col = questionary.text(
-        'Category column name? (leave blank if none)',
-        default=prompt_defaults['category_col'],
-    ).ask()
-    data_dirs_raw = questionary.text(
-        'Additional data directories? (comma-separated absolute paths, blank if none)',
-        default=prompt_defaults['data_dirs_raw'],
-    ).ask()
+
+    dataset_path = ''
+    question_col = ''
+    gt_col = ''
+    category_col = ''
+    harbor_tasks_root = ''
+
+    data_dirs_raw = ''
+    harbor_dataset_name = ''
+    if dataset_source == 'harbor':
+        if not _harbor_cli_available():
+            click.echo('\n  Warning: `harbor` CLI not found. Install with: pip install harbor')
+            click.echo('  You can still configure the project — download tasks manually later.\n')
+
+        # Pick dataset
+        available = _list_harbor_datasets(cwd)
+        if available:
+            harbor_dataset_name = _pick_harbor_dataset(available) or ''
+        if not harbor_dataset_name:
+            if not available:
+                click.echo('  Browse datasets at: https://hub.harborframework.com/datasets\n')
+            harbor_dataset_name = questionary.text(
+                'Dataset name (e.g. swe-bench/swe-bench-verified):',
+                validate=_require_non_empty,
+            ).ask()
+
+        harbor_tasks_root = questionary.text(
+            'Where to store Harbor tasks?',
+            default=prompt_defaults['harbor_tasks_root'],
+            validate=_require_non_empty,
+        ).ask()
+    else:
+        dataset_path = questionary.text(
+            'Absolute path to dataset CSV?',
+            default=prompt_defaults['dataset_path'],
+            validate=_require_non_empty,
+        ).ask()
+        question_col = questionary.text(
+            'Question/input column name?',
+            default=prompt_defaults['question_col'],
+            validate=_require_non_empty,
+        ).ask()
+        gt_col = questionary.text(
+            'Answer column name?',
+            default=prompt_defaults['gt_col'],
+            validate=_require_non_empty,
+        ).ask()
+        category_col = questionary.text(
+            'Category column name? (leave blank if none)',
+            default=prompt_defaults['category_col'],
+        ).ask()
+        data_dirs_raw = questionary.text(
+            'Additional data directories? (comma-separated absolute paths, blank if none)',
+            default=prompt_defaults['data_dirs_raw'],
+        ).ask()
 
     # 3. Execution mode
     exec_mode = questionary.select(
@@ -304,7 +553,7 @@ def init_cmd():
         ).ask()
 
         image_input = questionary.text(
-            'Docker image for sandbox? (build with: docker build -t evoskill .)',
+            'Docker image for sandbox?',
             default='',
         ).ask()
 
@@ -329,7 +578,12 @@ def init_cmd():
         else:
             click.echo('  No API key provided. Skipping Daytona setup.')
 
-    if any(v is None for v in [harness, dataset_path, question_col, gt_col, data_dirs_raw, exec_mode]):
+    required = [harness, dataset_source, exec_mode]
+    if dataset_source == 'harbor':
+        required.extend([harbor_dataset_name, harbor_tasks_root])
+    else:
+        required.extend([dataset_path, question_col, gt_col, data_dirs_raw])
+    if any(v is None for v in required):
         click.echo('\n  Aborted.')
         raise SystemExit(1)
 
@@ -343,6 +597,7 @@ def init_cmd():
         evoskill_dir / 'config.toml',
         {
             'harness': harness,
+            'dataset_source': dataset_source,
             'dataset_path': dataset_path,
             'question_col': question_col,
             'gt_col': gt_col,
@@ -350,9 +605,22 @@ def init_cmd():
             'data_dirs': data_dirs,
             'execution': exec_mode,
             'remote': remote_config,
+            'harbor_tasks_root': harbor_tasks_root,
         },
     )
     (evoskill_dir / 'task.md').write_text(TASK_MD_TEMPLATE)
+
+    # Auto-download Harbor dataset
+    harbor_downloaded = False
+    if dataset_source == 'harbor' and harbor_dataset_name and _harbor_cli_available():
+        output_dir = Path(harbor_tasks_root)
+        if not output_dir.is_absolute():
+            output_dir = cwd / output_dir
+        harbor_downloaded = _download_harbor_dataset(harbor_dataset_name, output_dir)
+        if harbor_downloaded:
+            click.echo(f'  ✓ Downloaded {harbor_dataset_name}')
+        else:
+            click.echo(f'  ✗ Download failed. Run manually: harbor datasets download {harbor_dataset_name} -o {harbor_tasks_root}')
 
     # Save init-time state (original branch for reset landing)
     original_branch = 'main'
@@ -369,28 +637,33 @@ def init_cmd():
 
     click.echo(f'\n  ✓ Created {cwd}/{EVOSKILL_DIR}')
     click.echo(f'    Runtime:   {harness}')
-    click.echo(f'    Dataset:   {dataset_path}')
-    click.echo(f'    Columns:   {question_col}, {gt_col}' + (f', {category_col}' if category_col else ''))
-    click.echo(f'    Data dirs: {", ".join(data_dirs) if data_dirs else "none"}')
+    if dataset_source == 'harbor':
+        click.echo(f'    Dataset:   Harbor — {harbor_dataset_name}')
+        click.echo(f'    Tasks dir: {harbor_tasks_root}')
+    else:
+        click.echo(f'    Dataset:   {dataset_path}')
+        click.echo(f'    Columns:   {question_col}, {gt_col}' + (f', {category_col}' if category_col else ''))
+        click.echo(f'    Data dirs: {", ".join(data_dirs) if data_dirs else "none"}')
     click.echo(f'    Execution: {exec_mode}')
     if remote_config:
         click.echo(f'    Image:     {remote_config["daytona"].get("image") or "(not set — build and push first)"}')
     click.echo('')
     click.echo('    Next:')
     click.echo(f'      1. Edit {EVOSKILL_DIR}/task.md with your task description')
-    if exec_mode == 'docker':
-        click.echo('      2. Build image: docker build -t evoskill .')
-        click.echo('      3. Run: evoskill run --docker')
-    elif exec_mode == 'daytona':
-        if not remote_config or not remote_config['daytona'].get('image'):
-            click.echo('      2. Build and push image:')
-            click.echo('         docker build -t evoskill .')
-            click.echo('         docker tag evoskill <registry>/evoskill:latest')
-            click.echo('         docker push <registry>/evoskill:latest')
-            click.echo('         Then set image in .evoskill/config.toml')
-        click.echo(f'      {"3" if not remote_config or not remote_config["daytona"].get("image") else "2"}. Run: evoskill run --remote')
+    if dataset_source == 'harbor' and not harbor_downloaded:
+        click.echo('      2. Install harbor CLI: pip install harbor')
+        click.echo(f'      3. Download tasks: harbor datasets download {harbor_dataset_name} -o {harbor_tasks_root}')
+        step = 4
+    elif dataset_source == 'harbor':
+        step = 2
     else:
-        click.echo('      2. Run: evoskill run')
+        step = 2
+    if exec_mode == 'docker':
+        click.echo(f'      {step}. Run: evoskill run --docker')
+    elif exec_mode == 'daytona':
+        click.echo(f'      {step}. Run: evoskill run --remote')
+    else:
+        click.echo(f'      {step}. Run: evoskill run')
     click.echo('')
     click.echo('    Note: Default iterations is set to 7. Increase iterations in')
     click.echo('    .evoskill/config.toml for better skill discovery.')

--- a/src/cli/commands/run.py
+++ b/src/cli/commands/run.py
@@ -337,6 +337,20 @@ def run_cmd(continue_loop: bool, verbose: bool, quiet: bool, config_path: Path |
     if not cfg.task_constraints and not quiet:
         console.print("[yellow]Warning:[/yellow] No constraints defined in task.md — skills may be unconstrained.")
 
+    # Validate harbor + dataset coherence
+    if cfg.harbor.enabled and cfg.dataset.source != "harbor":
+        console.print(
+            "[red]Error:[/red] harbor.enabled is true but dataset.source is "
+            f"'{cfg.dataset.source}'. Set dataset.source = \"harbor\" in config.toml."
+        )
+        raise SystemExit(1)
+    if cfg.dataset.source == "harbor" and not cfg.harbor.enabled:
+        console.print(
+            "[red]Error:[/red] dataset.source is 'harbor' but harbor.enabled is false. "
+            "Set harbor.enabled = true in config.toml."
+        )
+        raise SystemExit(1)
+
     console.print(f"\n  [bold]EvoSkill[/bold] — {cfg.evolution.mode}  |  {cfg.harness.name}  |  {cfg.evolution.iterations} iterations\n")
 
     if cfg.harness.name == "openhands":

--- a/src/cli/commands/run.py
+++ b/src/cli/commands/run.py
@@ -368,6 +368,15 @@ def run_cmd(continue_loop: bool, verbose: bool, quiet: bool, config_path: Path |
         )
         raise SystemExit(1)
 
+    # Auto-fix harbor.env when running on Daytona — Docker is not available in sandboxes
+    if cfg.harbor.enabled and cfg.execution == "daytona" and cfg.harbor.env == "docker":
+        cfg.harbor.env = "daytona"
+        if not quiet:
+            console.print(
+                "[yellow]Note:[/yellow] Overriding harbor.env to 'daytona' — "
+                "Docker is not available inside Daytona sandboxes."
+            )
+
     console.print(f"\n  [bold]EvoSkill[/bold] — {cfg.evolution.mode}  |  {cfg.harness.name}  |  {cfg.evolution.iterations} iterations\n")
 
     if cfg.harness.name == "openhands":

--- a/src/cli/commands/run.py
+++ b/src/cli/commands/run.py
@@ -351,8 +351,19 @@ def run_cmd(continue_loop: bool, verbose: bool, quiet: bool, config_path: Path |
     except FileNotFoundError:
         console.print(f"[red]Error:[/red] Dataset not found at {cfg.dataset_path}")
         raise SystemExit(1)
+    except Exception as exc:
+        # Catches HarborLoadError without importing it (avoids cycle).
+        if exc.__class__.__name__ == "HarborLoadError":
+            console.print(f"[red]Error:[/red] Harbor dataset: {exc}")
+            raise SystemExit(1)
+        raise
 
-    console.print(f"  Dataset: {cfg.dataset_path}  ({len(val_data)} val samples)\n")
+    if cfg.dataset.source == "harbor":
+        console.print(
+            f"  Harbor dataset: {cfg.dataset.harbor_tasks_root}  ({len(val_data)} val tasks)\n"
+        )
+    else:
+        console.print(f"  Dataset: {cfg.dataset_path}  ({len(val_data)} val samples)\n")
 
     # Build agents — use task.md description as the base agent prompt
     base_factory = make_base_agent_options_from_task(
@@ -361,13 +372,38 @@ def run_cmd(continue_loop: bool, verbose: bool, quiet: bool, config_path: Path |
         data_dirs=cfg.harness.data_dirs,
         project_root=cfg.project_root,
     )
-    agents = LoopAgents(
-        base=Agent(
+
+    if cfg.harbor.enabled:
+        from src.harness.harbor import HarborAgent
+        skills_source = cfg.project_root / ".claude" / "skills"
+        base_agent = HarborAgent(
+            project_root=cfg.project_root,
+            skills_source_dir=skills_source,
+            inner_agent=cfg.harbor.inner_agent,
+            inner_model=cfg.harbor.inner_model,
+            env=cfg.harbor.env,
+            n_concurrent=cfg.harbor.n_concurrent,
+            timeout_seconds=cfg.harness.timeout_seconds,
+            max_retries=cfg.harness.max_retries,
+            jobs_dir=Path(cfg.harbor.jobs_dir) if cfg.harbor.jobs_dir else None,
+            container_skills_path=cfg.harbor.container_skills_path,
+            timeout_multiplier=cfg.harbor.timeout_multiplier,
+            extra_args=cfg.harbor.extra_args,
+        )
+        console.print(
+            f"  [cyan]Harbor mode:[/cyan] inner agent={cfg.harbor.inner_agent}  "
+            f"env={cfg.harbor.env}  n_concurrent={cfg.harbor.n_concurrent}\n"
+        )
+    else:
+        base_agent = Agent(
             base_factory,
             AgentResponse,
             timeout_seconds=cfg.harness.timeout_seconds,
             max_retries=cfg.harness.max_retries,
-        ),
+        )
+
+    agents = LoopAgents(
+        base=base_agent,
         skill_proposer=Agent(
             make_skill_proposer_options(
                 project_root=cfg.project_root,

--- a/src/cli/commands/run.py
+++ b/src/cli/commands/run.py
@@ -20,6 +20,15 @@ from src.cli.report import RunReport, SkillEntry
 console = Console()
 
 
+def _is_under_project(path: Path, project_root: Path) -> bool:
+    """Check if path is inside the project root."""
+    try:
+        path.relative_to(project_root)
+        return True
+    except ValueError:
+        return False
+
+
 # ── display helpers ──────────────────────────────────────────────────────────
 
 def _build_table(rows: list[dict], baseline_score: float | None) -> Table:
@@ -241,11 +250,15 @@ def run_cmd(continue_loop: bool, verbose: bool, quiet: bool, config_path: Path |
             backend.setup(cfg)
             console.print(f" [green]done[/green]")
 
-            dataset_path = cfg.dataset_path.resolve()
             project_root = cfg.project_root.resolve()
-            external_dataset = not dataset_path.is_relative_to(project_root)
             external_dirs = [d for d in cfg.harness.data_dirs
                              if not Path(d).resolve().is_relative_to(project_root)]
+
+            if cfg.dataset.source == "harbor":
+                harbor_root = cfg.harbor_tasks_root_path.resolve()
+                external_harbor = not _is_under_project(harbor_root, project_root)
+            else:
+                external_harbor = False
 
             console.print("  [2/4] Uploading...")
             def _upload_log(msg):
@@ -253,8 +266,12 @@ def run_cmd(continue_loop: bool, verbose: bool, quiet: bool, config_path: Path |
             backend.upload(cfg, log=_upload_log)
             console.print(f"         [green]done[/green]")
             console.print(f"         project files → /workspace/")
-            if external_dataset:
-                console.print(f"         dataset ({dataset_path.name}) → /mnt/dataset/")
+            if cfg.dataset.source == "harbor" and external_harbor:
+                console.print(f"         harbor tasks ({harbor_root.name}) → /mnt/harbor_tasks/")
+            elif cfg.dataset.source != "harbor":
+                dataset_path = cfg.dataset_path.resolve()
+                if not _is_under_project(dataset_path, project_root):
+                    console.print(f"         dataset ({dataset_path.name}) → /mnt/dataset/")
             if external_dirs:
                 for d in external_dirs:
                     name = Path(d).name
@@ -376,7 +393,7 @@ def run_cmd(continue_loop: bool, verbose: bool, quiet: bool, config_path: Path |
 
     if cfg.dataset.source == "harbor":
         console.print(
-            f"  Harbor dataset: {cfg.dataset.harbor_tasks_root}  ({len(val_data)} val tasks)\n"
+            f"  Harbor dataset: {cfg.harbor_tasks_root_path}  ({len(val_data)} val tasks)\n"
         )
     else:
         console.print(f"  Dataset: {cfg.dataset_path}  ({len(val_data)} val samples)\n")

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -146,6 +146,15 @@ class ProjectConfig:
         path = Path(self.dataset.path)
         return path if path.is_absolute() else self.project_root / path
 
+    @property
+    def harbor_tasks_root_path(self) -> Path:
+        """Return the harbor tasks root, with container override and relative path support."""
+        override = _docker_path_overrides().get("harbor_tasks_root")
+        if override:
+            return Path(override)
+        path = Path(self.dataset.harbor_tasks_root)
+        return path if path.is_absolute() else self.project_root / path
+
 
 def _find_project_root(start: Path | None = None) -> Path | None:
     """Walk up from start looking for a .evoskill/ directory."""

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -49,17 +49,43 @@ class EvolutionConfig:
 
 @dataclass
 class DatasetConfig:
+    source: Literal['csv', 'harbor'] = 'csv'
     path: str = '/absolute/path/to/questions.csv'
     question_column: str = 'question'
     ground_truth_column: str = 'ground_truth'
     category_column: str | None = None
     train_ratio: float = 0.18
     val_ratio: float = 0.12
+    # Harbor-specific (only used when source == "harbor")
+    harbor_tasks_root: str = ''       # path to a downloaded harbor dataset dir
+    harbor_limit: int | None = None   # max tasks to include
+    harbor_include: list[str] = field(default_factory=list)  # glob patterns on task id
+    harbor_exclude: list[str] = field(default_factory=list)
+    harbor_difficulty: list[str] = field(default_factory=list)  # e.g. ["easy"] — empty = no filter
+
+
+@dataclass
+class HarborConfig:
+    """Run the base agent inside Harbor sandboxes instead of via the LLM SDK.
+
+    When enabled, the base agent's run() invokes `harbor run -p <task>` with
+    EvoSkill's evolved skills mounted, and reads the reward from reward.txt.
+    Proposer/generator agents continue to use harness.name's SDK normally.
+    """
+    enabled: bool = False
+    inner_agent: str = 'claude-code'           # one of harbor's registered agents
+    inner_model: str = 'anthropic/claude-sonnet-4-5'
+    env: Literal['docker', 'daytona', 'modal', 'e2b', 'runloop'] = 'docker'
+    n_concurrent: int = 1                      # parallel trials per harbor invocation
+    timeout_multiplier: float = 1.0
+    jobs_dir: str = ''                         # where to drop harbor jobs/<id>/ output (default: <project>/.evoskill/harbor_jobs)
+    container_skills_path: str = '/skills'     # path inside container we mount evolved skills to
+    extra_args: list[str] = field(default_factory=list)  # passthrough to harbor run
 
 
 @dataclass
 class ScorerConfig:
-    type: Literal['exact', 'multi_tolerance', 'llm', 'script'] = 'multi_tolerance'
+    type: Literal['exact', 'multi_tolerance', 'llm', 'script', 'harbor'] = 'multi_tolerance'
     rubric: str | None = None
     model: str | None = None
     provider: str | None = None
@@ -101,6 +127,7 @@ class ProjectConfig:
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     scorer: ScorerConfig = field(default_factory=ScorerConfig)
     remote: RemoteConfig | None = None
+    harbor: HarborConfig = field(default_factory=HarborConfig)
     execution: str = 'local'  # 'local', 'docker', or 'daytona'
     project_root: Path = field(default_factory=Path.cwd)
     task_description: str = ''
@@ -231,12 +258,17 @@ def load_config(
 
     execution = raw.get('execution', 'local')
 
+    # Parse [harbor] section (optional)
+    harbor_raw = dict(raw.get('harbor', {}))
+    harbor = HarborConfig(**harbor_raw) if harbor_raw else HarborConfig()
+
     return ProjectConfig(
         harness=harness,
         evolution=evolution,
         dataset=dataset,
         scorer=scorer,
         remote=remote,
+        harbor=harbor,
         execution=execution,
         project_root=root,
         task_description=description,

--- a/src/cli/shared.py
+++ b/src/cli/shared.py
@@ -15,21 +15,25 @@ if TYPE_CHECKING:
 def load_and_split(cfg: ProjectConfig):
     from src.api.data_utils import stratified_split
 
-    data = pd.read_csv(cfg.dataset_path)
+    if cfg.dataset.source == "harbor":
+        from src.api.harbor_loader import load_harbor_tasks
+        data = load_harbor_tasks(cfg)
+    else:
+        data = pd.read_csv(cfg.dataset_path)
 
-    renames: dict[str, str] = {}
-    if cfg.dataset.question_column != "question":
-        renames[cfg.dataset.question_column] = "question"
-    if cfg.dataset.ground_truth_column != "ground_truth":
-        renames[cfg.dataset.ground_truth_column] = "ground_truth"
-    if renames:
-        data.rename(columns=renames, inplace=True)
+        renames: dict[str, str] = {}
+        if cfg.dataset.question_column != "question":
+            renames[cfg.dataset.question_column] = "question"
+        if cfg.dataset.ground_truth_column != "ground_truth":
+            renames[cfg.dataset.ground_truth_column] = "ground_truth"
+        if renames:
+            data.rename(columns=renames, inplace=True)
 
-    if cfg.dataset.category_column and cfg.dataset.category_column in data.columns:
-        if cfg.dataset.category_column != "category":
-            data.rename(columns={cfg.dataset.category_column: "category"}, inplace=True)
-    elif "category" not in data.columns:
-        data["category"] = "default"
+        if cfg.dataset.category_column and cfg.dataset.category_column in data.columns:
+            if cfg.dataset.category_column != "category":
+                data.rename(columns={cfg.dataset.category_column: "category"}, inplace=True)
+        elif "category" not in data.columns:
+            data["category"] = "default"
 
     return stratified_split(
         data,
@@ -152,6 +156,10 @@ async def call_llm(provider: str, model: str, prompt: str) -> str:
 
 def make_scorer(cfg: ProjectConfig):
     from src.loop.runner import _score_multi_tolerance
+
+    if cfg.scorer.type == "harbor":
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        return harbor_reward_scorer
 
     if cfg.scorer.type == "exact":
 

--- a/src/docker/launcher.py
+++ b/src/docker/launcher.py
@@ -31,14 +31,23 @@ def _build_compose(cfg: ProjectConfig, extra_args: list[str]) -> dict:
     # Path overrides for dataset/data_dirs inside the container
     path_overrides: dict[str, str] = {}
 
-    # Mount dataset if external
-    dataset_path = cfg.dataset_path.resolve()
-    try:
-        dataset_path.relative_to(project_root)
-    except ValueError:
-        container_dataset = f"/mnt/dataset/{dataset_path.name}"
-        volumes.append(f"{dataset_path}:{container_dataset}:ro")
-        path_overrides["dataset_path"] = container_dataset
+    # Mount dataset / harbor tasks if external
+    if cfg.dataset.source == "harbor":
+        harbor_root = cfg.harbor_tasks_root_path.resolve()
+        try:
+            harbor_root.relative_to(project_root)
+        except ValueError:
+            container_harbor = "/mnt/harbor_tasks"
+            volumes.append(f"{harbor_root}:{container_harbor}:ro")
+            path_overrides["harbor_tasks_root"] = container_harbor
+    else:
+        dataset_path = cfg.dataset_path.resolve()
+        try:
+            dataset_path.relative_to(project_root)
+        except ValueError:
+            container_dataset = f"/mnt/dataset/{dataset_path.name}"
+            volumes.append(f"{dataset_path}:{container_dataset}:ro")
+            path_overrides["dataset_path"] = container_dataset
 
     # Mount external data dirs
     container_data_dirs = []

--- a/src/evaluation/harbor_scorer.py
+++ b/src/evaluation/harbor_scorer.py
@@ -1,0 +1,31 @@
+"""Scorer for predictions produced by HarborAgent.
+
+HarborAgent encodes each Harbor trial's outcome as a JSON envelope in
+trace.output.final_answer:
+
+    {"reward": 1.0, "metric": "reward.txt", "exit_status": "verified"}
+
+This scorer just decodes that envelope and returns the primary reward. The
+ground_truth argument is ignored by design — Harbor's in-container verifier is
+the source of truth, and HarborAgent has already collapsed it into a number.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def harbor_reward_scorer(question: str, predicted: str, ground_truth: str) -> float:
+    if not predicted:
+        return 0.0
+    try:
+        envelope = json.loads(predicted)
+    except (TypeError, ValueError):
+        return 0.0
+    if not isinstance(envelope, dict):
+        return 0.0
+    raw = envelope.get("reward", 0.0)
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 0.0

--- a/src/harness/harbor/__init__.py
+++ b/src/harness/harbor/__init__.py
@@ -1,0 +1,11 @@
+"""Harbor harness — run the base agent inside Harbor sandboxes.
+
+Unlike the other harness submodules (claude/, opencode/, ...) which are SDK
+adapters that talk directly to LLMs, this one delegates execution to the
+`harbor` CLI. The agent's "query" is a Harbor task id; the response is a JSON
+envelope wrapping the verifier's reward.
+"""
+
+from .agent import HarborAgent, HarborRunError
+
+__all__ = ["HarborAgent", "HarborRunError"]

--- a/src/harness/harbor/agent.py
+++ b/src/harness/harbor/agent.py
@@ -1,0 +1,313 @@
+"""HarborAgent: drop-in replacement for the base Agent that runs Harbor trials.
+
+For each query (a Harbor task id), this agent:
+
+  1. Resolves the task id to a local digest directory (populated by harbor_loader).
+  2. Mounts EvoSkill's current `.claude/skills/` into the container at a known
+     path via `--mounts-json`.
+  3. Tells the inner agent (claude-code, openhands, ...) to read skills from
+     that mount via `--ak skills_dir=<mount>`.
+  4. Spawns `harbor run` as a subprocess.
+  5. Reads the trial's verifier reward (reward.txt or reward.json) from the
+     emitted jobs directory.
+  6. Returns an AgentTrace whose output.final_answer is a JSON envelope:
+        {"reward": <float>, "task_id": <id>, "exit_status": <str>}
+
+The harbor scorer (src.evaluation.harbor_scorer) reads that envelope back.
+
+Why a JSON envelope instead of returning a float directly: EvoSkill's loop
+expects a string in `output.final_answer` and computes scores via a scorer
+function. We keep that contract intact.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from src.harness.agent import Agent, AgentTrace
+from src.schemas import AgentResponse
+
+logger = logging.getLogger(__name__)
+
+
+class HarborRunError(RuntimeError):
+    pass
+
+
+class HarborAgent(Agent[AgentResponse]):
+    """Run a Harbor task as an EvoSkill agent."""
+
+    def __init__(
+        self,
+        *,
+        project_root: Path,
+        skills_source_dir: Path,
+        inner_agent: str,
+        inner_model: str,
+        env: str = "docker",
+        n_concurrent: int = 1,
+        timeout_seconds: int = 1800,
+        max_retries: int = 1,
+        jobs_dir: Path | None = None,
+        container_skills_path: str = "/skills",
+        timeout_multiplier: float = 1.0,
+        extra_args: list[str] | None = None,
+    ):
+        # The base Agent class expects options + response_model. We pass placeholders
+        # because we override run() entirely and never delegate to an SDK executor.
+        super().__init__(
+            options=lambda: {},
+            response_model=AgentResponse,
+            timeout_seconds=timeout_seconds,
+            max_retries=max_retries,
+        )
+        self.project_root = Path(project_root)
+        self.skills_source_dir = Path(skills_source_dir)
+        self.inner_agent = inner_agent
+        self.inner_model = inner_model
+        self.env = env
+        self.n_concurrent = max(1, int(n_concurrent))
+        self.jobs_dir = (
+            Path(jobs_dir)
+            if jobs_dir
+            else (self.project_root / ".evoskill" / "harbor_jobs")
+        )
+        self.container_skills_path = container_skills_path
+        self.timeout_multiplier = float(timeout_multiplier)
+        self.extra_args = list(extra_args or [])
+
+    # ------------------------------------------------------------------ public
+    async def run(self, query: str) -> AgentTrace[AgentResponse]:
+        """Execute the Harbor task identified by `query` and return a trace."""
+        from src.api.harbor_loader import resolve_task_dir
+
+        started_ms = time.monotonic()
+        task_dir = resolve_task_dir(query)
+        if task_dir is None:
+            return self._error_trace(
+                query, started_ms, f"unknown harbor task id: {query!r}"
+            )
+        if not (task_dir / "task.toml").is_file():
+            return self._error_trace(
+                query, started_ms, f"no task.toml in {task_dir}"
+            )
+
+        job_name = f"evoskill-{uuid.uuid4().hex[:12]}"
+        job_dir = self.jobs_dir / job_name
+        job_dir.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = self._build_command(task_dir, job_name)
+        env_vars = self._build_env()
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env_vars,
+            )
+        except FileNotFoundError as exc:
+            return self._error_trace(
+                query,
+                started_ms,
+                f"`harbor` CLI not found on PATH: {exc}. "
+                "Install with: uv tool install harbor",
+            )
+
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=self.timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return self._error_trace(
+                query,
+                started_ms,
+                f"harbor run timed out after {self.timeout_seconds}s",
+            )
+
+        stdout = stdout_b.decode("utf-8", errors="replace")
+        stderr = stderr_b.decode("utf-8", errors="replace")
+        exit_code = proc.returncode or 0
+
+        reward, exit_status = self._read_reward(job_dir)
+        if reward is None:
+            # Surface harbor's stderr tail so failures are diagnosable upstream.
+            tail = stderr[-4000:] if stderr else stdout[-4000:]
+            return self._error_trace(
+                query,
+                started_ms,
+                f"harbor exit={exit_code}; no reward found under {job_dir}.\n"
+                f"--- harbor stderr/stdout tail ---\n{tail}",
+            )
+
+        envelope = {
+            "reward": float(reward),
+            "task_id": query,
+            "exit_status": exit_status,
+            "job_dir": str(job_dir),
+        }
+        duration_ms = int((time.monotonic() - started_ms) * 1000)
+        return AgentTrace(
+            uuid=job_name,
+            session_id=job_name,
+            model=f"harbor:{self.inner_agent}:{self.inner_model}",
+            tools=[],
+            duration_ms=duration_ms,
+            total_cost_usd=0.0,
+            num_turns=1,
+            usage={},
+            result=stdout[-2000:],
+            is_error=exit_code != 0 and reward == 0.0,
+            output=AgentResponse(
+                final_answer=json.dumps(envelope),
+                reasoning=f"harbor:{self.inner_agent} task={query}",
+            ),
+            messages=[],
+        )
+
+    # ------------------------------------------------------------ command build
+    def _build_command(self, task_dir: Path, job_name: str) -> list[str]:
+        skills_mount = self._build_skills_mount()
+        cmd: list[str] = [
+            "harbor",
+            "run",
+            "-p",
+            str(task_dir),
+            "-a",
+            self.inner_agent,
+            "-m",
+            self.inner_model,
+            "-e",
+            self.env,
+            "-n",
+            str(self.n_concurrent),
+            "--quiet",
+            "--yes",
+            "--job-name",
+            job_name,
+            "--jobs-dir",
+            str(self.jobs_dir),
+            "--max-retries",
+            "0",
+            "--timeout-multiplier",
+            f"{self.timeout_multiplier}",
+        ]
+        if skills_mount is not None:
+            cmd.extend(["--mounts-json", json.dumps([skills_mount])])
+            cmd.extend(["--ak", f"skills_dir={self.container_skills_path}"])
+        cmd.extend(self.extra_args)
+        return cmd
+
+    def _build_skills_mount(self) -> dict[str, Any] | None:
+        if not self.skills_source_dir.is_dir():
+            return None
+        try:
+            has_content = any(self.skills_source_dir.iterdir())
+        except OSError:
+            has_content = False
+        if not has_content:
+            return None
+        return {
+            "type": "bind",
+            "source": str(self.skills_source_dir.resolve()),
+            "target": self.container_skills_path,
+            "read_only": True,
+        }
+
+    def _build_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        # Pass the current working dir as context but don't leak project secrets.
+        # The inner agent (claude-code, etc.) needs its own provider key in env.
+        return env
+
+    # -------------------------------------------------------------- reward read
+    def _read_reward(self, job_dir: Path) -> tuple[float | None, str]:
+        """Return (reward, exit_status). reward is None if no file was found."""
+        if not job_dir.is_dir():
+            return None, "no_job_dir"
+
+        # Prefer the structured trial result.json (TrialResult schema).
+        for result_path in sorted(job_dir.rglob("result.json")):
+            try:
+                payload = json.loads(result_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            verifier = payload.get("verifier_result") or {}
+            rewards = verifier.get("rewards") or {}
+            if rewards:
+                # Pick "reward" if present, else the first value.
+                if "reward" in rewards:
+                    return float(rewards["reward"]), "verified"
+                first = next(iter(rewards.values()))
+                try:
+                    return float(first), "verified"
+                except (TypeError, ValueError):
+                    pass
+
+        # Fallback: read reward.txt directly from any verifier dir.
+        for reward_path in sorted(job_dir.rglob("verifier/reward.txt")):
+            try:
+                return float(reward_path.read_text().strip()), "verified"
+            except (OSError, ValueError):
+                continue
+
+        # Reward.json fallback
+        for reward_json in sorted(job_dir.rglob("verifier/reward.json")):
+            try:
+                payload = json.loads(reward_json.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(payload, dict) and payload:
+                first = next(iter(payload.values()))
+                try:
+                    return float(first), "verified"
+                except (TypeError, ValueError):
+                    continue
+
+        return None, "no_reward"
+
+    # ------------------------------------------------------------- error helper
+    def _error_trace(
+        self, query: str, started_ms: float, message: str
+    ) -> AgentTrace[AgentResponse]:
+        envelope = {
+            "reward": 0.0,
+            "task_id": query,
+            "exit_status": "error",
+            "error": message,
+        }
+        duration_ms = int((time.monotonic() - started_ms) * 1000)
+        return AgentTrace(
+            uuid="",
+            session_id="",
+            model=f"harbor:{self.inner_agent}:{self.inner_model}",
+            tools=[],
+            duration_ms=duration_ms,
+            total_cost_usd=0.0,
+            num_turns=0,
+            usage={},
+            result=message,
+            is_error=True,
+            output=AgentResponse(
+                final_answer=json.dumps(envelope),
+                reasoning=f"harbor:{self.inner_agent} task={query}",
+            ),
+            parse_error=None,
+            messages=[],
+        )
+
+    # Optional cleanup hook (not currently called, but useful for tests).
+    def cleanup_jobs_dir(self) -> None:
+        if self.jobs_dir.is_dir():
+            shutil.rmtree(self.jobs_dir, ignore_errors=True)

--- a/src/remote/daytona.py
+++ b/src/remote/daytona.py
@@ -307,14 +307,23 @@ class DaytonaBackend(RemoteBackend):
             cwd="/workspace",
         )
 
+        # Ensure harbor CLI is available when harbor mode is enabled
+        if cfg.harbor.enabled:
+            sandbox.process.exec(
+                "which harbor > /dev/null 2>&1 || pip install harbor 2>&1",
+            )
+
         # Preflight checks
-        preflight = sandbox.process.exec(
+        preflight_cmd = (
             "echo '=== evoskill ===' && which evoskill && "
             "echo '=== ANTHROPIC_API_KEY ===' && "
             "([ -n \"$ANTHROPIC_API_KEY\" ] && echo 'set' || echo 'NOT SET') && "
             "echo '=== python ===' && python --version && "
-            "echo '=== git ===' && git --version",
+            "echo '=== git ===' && git --version"
         )
+        if cfg.harbor.enabled:
+            preflight_cmd += " && echo '=== harbor ===' && which harbor && harbor --version"
+        preflight = sandbox.process.exec(preflight_cmd)
         if "NOT SET" in preflight.result and cfg.harness.name == "claude":
             raise RuntimeError(
                 f"Preflight failed: ANTHROPIC_API_KEY not set in sandbox.\n"

--- a/src/remote/daytona.py
+++ b/src/remote/daytona.py
@@ -242,8 +242,8 @@ class DaytonaBackend(RemoteBackend):
                     raise RuntimeError(
                         f"Data directory '{mapping.host_path.name}' is too large "
                         f"({tar_size / 1024 / 1024:.0f}MB compressed) for Daytona upload. "
-                        f"Max is 1GB. Host the data externally and download it in the "
-                        f"remote command, or remove it from data_dirs."
+                        f"Max is 1GB. Try running with Docker (evoskill run --docker) "
+                        f"or locally (evoskill run) instead."
                     )
 
                 tar_bytes = Path(tar_path).read_bytes()

--- a/src/remote/daytona.py
+++ b/src/remote/daytona.py
@@ -89,12 +89,14 @@ def _is_under(path: Path, parent: Path) -> bool:
 
 
 def _collect_api_keys() -> dict[str, str]:
-    """Collect LLM API keys from environment."""
+    """Collect LLM and infrastructure API keys from environment."""
     keys = [
         "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
         "LLM_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY",
         "GROQ_API_KEY", "MISTRAL_API_KEY", "TOGETHER_API_KEY",
         "DEEPSEEK_API_KEY", "XAI_API_KEY",
+        # Infrastructure keys — needed by Harbor when env=daytona
+        "DAYTONA_API_KEY",
     ]
     return {k: os.environ[k] for k in keys if k in os.environ}
 

--- a/src/remote/daytona.py
+++ b/src/remote/daytona.py
@@ -203,7 +203,9 @@ class DaytonaBackend(RemoteBackend):
                 Path(tar_path).unlink(missing_ok=True)
                 remote_tar = "/tmp/harbor_tasks.tar.gz"
                 sandbox.fs.upload_file(tar_bytes, remote_tar)
-                sandbox.process.exec(
+                _exec_async(
+                    sandbox,
+                    UPLOAD_SESSION_ID,
                     f"mkdir -p {container_harbor} && "
                     f"tar xzf {remote_tar} -C {container_harbor} --strip-components=1 && "
                     f"rm {remote_tar}",

--- a/src/remote/daytona.py
+++ b/src/remote/daytona.py
@@ -148,14 +148,37 @@ class DaytonaBackend(RemoteBackend):
             sandbox.fs.create_folder(parent, mode="755")
             sandbox.fs.upload_file(file_path.read_bytes(), remote_path)
 
-        # 3. Upload dataset if external
-        dataset_path = cfg.dataset_path.resolve()
-        if not _is_under(dataset_path, project_root.resolve()):
-            log(f"dataset ({dataset_path.name})...")
-            container_dataset = f"/mnt/dataset/{dataset_path.name}"
-            sandbox.fs.create_folder("/mnt/dataset", mode="755")
-            sandbox.fs.upload_file(dataset_path.read_bytes(), container_dataset)
-            self._path_overrides["dataset_path"] = container_dataset
+        # 3. Upload dataset or harbor tasks if external
+        if cfg.dataset.source == "harbor":
+            harbor_root = cfg.harbor_tasks_root_path.resolve()
+            if not _is_under(harbor_root, project_root.resolve()):
+                log(f"harbor tasks ({harbor_root.name})...")
+                container_harbor = "/mnt/harbor_tasks"
+                # Tar and upload the harbor tasks directory
+                with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+                    tar_path = f.name
+                subprocess.run(
+                    ["tar", "czf", tar_path, "-C", str(harbor_root.parent), harbor_root.name],
+                    check=True,
+                )
+                tar_bytes = Path(tar_path).read_bytes()
+                Path(tar_path).unlink(missing_ok=True)
+                remote_tar = "/tmp/harbor_tasks.tar.gz"
+                sandbox.fs.upload_file(tar_bytes, remote_tar)
+                sandbox.process.exec(
+                    f"mkdir -p {container_harbor} && "
+                    f"tar xzf {remote_tar} -C {container_harbor} --strip-components=1 && "
+                    f"rm {remote_tar}",
+                )
+                self._path_overrides["harbor_tasks_root"] = container_harbor
+        else:
+            dataset_path = cfg.dataset_path.resolve()
+            if not _is_under(dataset_path, project_root.resolve()):
+                log(f"dataset ({dataset_path.name})...")
+                container_dataset = f"/mnt/dataset/{dataset_path.name}"
+                sandbox.fs.create_folder("/mnt/dataset", mode="755")
+                sandbox.fs.upload_file(dataset_path.read_bytes(), container_dataset)
+                self._path_overrides["dataset_path"] = container_dataset
 
         # 4. Upload external data dirs via tar (chunked if > 50MB)
         MAX_CHUNK = 50 * 1024 * 1024

--- a/tests/test_harbor.py
+++ b/tests/test_harbor.py
@@ -1,0 +1,555 @@
+"""Tests for Harbor integration — loader, scorer, agent, config validation, docker/daytona."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.cli.config import (
+    DatasetConfig,
+    HarborConfig,
+    HarnessConfig,
+    ProjectConfig,
+    ScorerConfig,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_harbor_cfg(tmp_path, *, harbor_enabled=True, dataset_source="harbor",
+                     harbor_tasks_root=None, inner_agent="claude-code",
+                     inner_model="anthropic/claude-sonnet-4-5", env="docker"):
+    (tmp_path / ".evoskill").mkdir(exist_ok=True)
+    root = harbor_tasks_root or str(tmp_path / "tasks")
+    return ProjectConfig(
+        harness=HarnessConfig(name="claude"),
+        dataset=DatasetConfig(source=dataset_source, harbor_tasks_root=root),
+        scorer=ScorerConfig(type="harbor" if dataset_source == "harbor" else "multi_tolerance"),
+        harbor=HarborConfig(
+            enabled=harbor_enabled,
+            inner_agent=inner_agent,
+            inner_model=inner_model,
+            env=env,
+        ),
+        project_root=tmp_path,
+    )
+
+
+def _make_task_dir(root: Path, org: str, name: str, *,
+                   category: str = "default", difficulty: str = "default") -> Path:
+    """Create a minimal Harbor task directory with task.toml."""
+    digest = "abc123"
+    task_dir = root / org / name / digest
+    task_dir.mkdir(parents=True)
+    toml = (
+        f'[task]\nname = "{org}/{name}"\n\n'
+        f'[metadata]\ncategory = "{category}"\ndifficulty = "{difficulty}"\n'
+    )
+    (task_dir / "task.toml").write_text(toml)
+    return task_dir
+
+
+# ── harbor_loader ────────────────────────────────────────────────────────────
+
+
+class TestHarborLoader:
+
+    def test_load_discovers_tasks(self, tmp_path):
+        from src.api.harbor_loader import load_harbor_tasks
+        root = tmp_path / "tasks"
+        _make_task_dir(root, "org1", "task_a")
+        _make_task_dir(root, "org1", "task_b")
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(root))
+        df = load_harbor_tasks(cfg)
+        assert len(df) == 2
+        assert set(df["question"]) == {"org1/task_a", "org1/task_b"}
+
+    def test_load_populates_task_path_index(self, tmp_path):
+        from src.api.harbor_loader import TASK_PATH_INDEX, load_harbor_tasks
+        root = tmp_path / "tasks"
+        _make_task_dir(root, "myorg", "mytask")
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(root))
+        load_harbor_tasks(cfg)
+        assert "myorg/mytask" in TASK_PATH_INDEX
+        assert TASK_PATH_INDEX["myorg/mytask"].is_dir()
+
+    def test_load_sets_ground_truth_sentinel(self, tmp_path):
+        from src.api.harbor_loader import load_harbor_tasks
+        root = tmp_path / "tasks"
+        _make_task_dir(root, "org", "t1")
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(root))
+        df = load_harbor_tasks(cfg)
+        assert df["ground_truth"].iloc[0] == "1.0"
+
+    def test_load_reads_category(self, tmp_path):
+        from src.api.harbor_loader import load_harbor_tasks
+        root = tmp_path / "tasks"
+        _make_task_dir(root, "org", "t1", category="math")
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(root))
+        df = load_harbor_tasks(cfg)
+        assert df["category"].iloc[0] == "math"
+
+    def test_load_filters_by_include(self, tmp_path):
+        from src.api.harbor_loader import load_harbor_tasks
+        root = tmp_path / "tasks"
+        _make_task_dir(root, "org", "keep_me")
+        _make_task_dir(root, "org", "skip_me")
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(root))
+        cfg.dataset.harbor_include = ["org/keep*"]
+        df = load_harbor_tasks(cfg)
+        assert len(df) == 1
+        assert df["question"].iloc[0] == "org/keep_me"
+
+    def test_load_filters_by_exclude(self, tmp_path):
+        from src.api.harbor_loader import load_harbor_tasks
+        root = tmp_path / "tasks"
+        _make_task_dir(root, "org", "good")
+        _make_task_dir(root, "org", "bad")
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(root))
+        cfg.dataset.harbor_exclude = ["org/bad"]
+        df = load_harbor_tasks(cfg)
+        assert len(df) == 1
+        assert df["question"].iloc[0] == "org/good"
+
+    def test_load_filters_by_difficulty(self, tmp_path):
+        from src.api.harbor_loader import load_harbor_tasks
+        root = tmp_path / "tasks"
+        _make_task_dir(root, "org", "easy_one", difficulty="easy")
+        _make_task_dir(root, "org", "hard_one", difficulty="hard")
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(root))
+        cfg.dataset.harbor_difficulty = ["easy"]
+        df = load_harbor_tasks(cfg)
+        assert len(df) == 1
+        assert df["question"].iloc[0] == "org/easy_one"
+
+    def test_load_respects_limit(self, tmp_path):
+        from src.api.harbor_loader import load_harbor_tasks
+        root = tmp_path / "tasks"
+        for i in range(5):
+            _make_task_dir(root, "org", f"task_{i:02d}")
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(root))
+        cfg.dataset.harbor_limit = 3
+        df = load_harbor_tasks(cfg)
+        assert len(df) == 3
+
+    def test_load_raises_on_missing_root(self, tmp_path):
+        from src.api.harbor_loader import HarborLoadError, load_harbor_tasks
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(tmp_path / "nonexistent"))
+        with pytest.raises(HarborLoadError, match="does not exist"):
+            load_harbor_tasks(cfg)
+
+    def test_load_raises_on_empty_root(self, tmp_path):
+        from src.api.harbor_loader import HarborLoadError, load_harbor_tasks
+        root = tmp_path / "empty_tasks"
+        root.mkdir()
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(root))
+        with pytest.raises(HarborLoadError, match="no task.toml"):
+            load_harbor_tasks(cfg)
+
+    def test_load_raises_on_blank_root(self, tmp_path):
+        from src.api.harbor_loader import HarborLoadError, load_harbor_tasks
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root="")
+        with pytest.raises(HarborLoadError):
+            load_harbor_tasks(cfg)
+
+    def test_load_filters_leave_nothing_raises(self, tmp_path):
+        from src.api.harbor_loader import HarborLoadError, load_harbor_tasks
+        root = tmp_path / "tasks"
+        _make_task_dir(root, "org", "only_task")
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(root))
+        cfg.dataset.harbor_include = ["nonexistent/*"]
+        with pytest.raises(HarborLoadError, match="no tasks to run"):
+            load_harbor_tasks(cfg)
+
+    def test_resolve_task_dir_returns_path(self, tmp_path):
+        from src.api.harbor_loader import (
+            TASK_PATH_INDEX,
+            load_harbor_tasks,
+            resolve_task_dir,
+        )
+        root = tmp_path / "tasks"
+        td = _make_task_dir(root, "org", "t1")
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(root))
+        load_harbor_tasks(cfg)
+        assert resolve_task_dir("org/t1") == td
+
+    def test_resolve_task_dir_returns_none_for_unknown(self):
+        from src.api.harbor_loader import resolve_task_dir
+        assert resolve_task_dir("nonexistent/task") is None
+
+    def test_load_relative_path_resolved_to_project_root(self, tmp_path):
+        from src.api.harbor_loader import load_harbor_tasks
+        root = tmp_path / "rel_tasks"
+        _make_task_dir(root, "org", "t1")
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root="rel_tasks")
+        df = load_harbor_tasks(cfg)
+        assert len(df) == 1
+
+
+# ── harbor_scorer ────────────────────────────────────────────────────────────
+
+
+class TestHarborScorer:
+
+    def test_valid_envelope(self):
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        envelope = json.dumps({"reward": 0.75, "task_id": "org/t1", "exit_status": "verified"})
+        assert harbor_reward_scorer("q", envelope, "gt") == 0.75
+
+    def test_perfect_score(self):
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        envelope = json.dumps({"reward": 1.0})
+        assert harbor_reward_scorer("q", envelope, "gt") == 1.0
+
+    def test_zero_score(self):
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        envelope = json.dumps({"reward": 0.0})
+        assert harbor_reward_scorer("q", envelope, "gt") == 0.0
+
+    def test_empty_prediction_returns_zero(self):
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        assert harbor_reward_scorer("q", "", "gt") == 0.0
+
+    def test_none_prediction_returns_zero(self):
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        assert harbor_reward_scorer("q", None, "gt") == 0.0
+
+    def test_invalid_json_returns_zero(self):
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        assert harbor_reward_scorer("q", "not json", "gt") == 0.0
+
+    def test_missing_reward_key_returns_zero(self):
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        envelope = json.dumps({"task_id": "org/t1"})
+        assert harbor_reward_scorer("q", envelope, "gt") == 0.0
+
+    def test_non_numeric_reward_returns_zero(self):
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        envelope = json.dumps({"reward": "not_a_number"})
+        assert harbor_reward_scorer("q", envelope, "gt") == 0.0
+
+    def test_json_list_returns_zero(self):
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        assert harbor_reward_scorer("q", "[1, 2, 3]", "gt") == 0.0
+
+    def test_ground_truth_is_ignored(self):
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        envelope = json.dumps({"reward": 0.5})
+        assert harbor_reward_scorer("q", envelope, "anything") == 0.5
+        assert harbor_reward_scorer("q", envelope, "") == 0.5
+
+
+# ── HarborAgent ──────────────────────────────────────────────────────────────
+
+
+class TestHarborAgent:
+
+    def _make_agent(self, tmp_path, **kwargs):
+        from src.harness.harbor import HarborAgent
+        defaults = dict(
+            project_root=tmp_path,
+            skills_source_dir=tmp_path / "skills",
+            inner_agent="claude-code",
+            inner_model="anthropic/claude-sonnet-4-5",
+        )
+        defaults.update(kwargs)
+        return HarborAgent(**defaults)
+
+    def test_default_jobs_dir(self, tmp_path):
+        agent = self._make_agent(tmp_path)
+        assert agent.jobs_dir == tmp_path / ".evoskill" / "harbor_jobs"
+
+    def test_custom_jobs_dir(self, tmp_path):
+        custom = tmp_path / "my_jobs"
+        agent = self._make_agent(tmp_path, jobs_dir=custom)
+        assert agent.jobs_dir == custom
+
+    def test_n_concurrent_minimum_is_one(self, tmp_path):
+        agent = self._make_agent(tmp_path, n_concurrent=0)
+        assert agent.n_concurrent == 1
+
+    def test_build_command_basic(self, tmp_path):
+        agent = self._make_agent(tmp_path)
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        cmd = agent._build_command(task_dir, "job-1")
+        assert cmd[0] == "harbor"
+        assert cmd[1] == "run"
+        assert "-p" in cmd
+        assert str(task_dir) in cmd
+        assert "-a" in cmd
+        idx = cmd.index("-a")
+        assert cmd[idx + 1] == "claude-code"
+
+    def test_build_command_includes_model(self, tmp_path):
+        agent = self._make_agent(tmp_path)
+        cmd = agent._build_command(tmp_path, "j1")
+        idx = cmd.index("-m")
+        assert cmd[idx + 1] == "anthropic/claude-sonnet-4-5"
+
+    def test_build_command_includes_extra_args(self, tmp_path):
+        agent = self._make_agent(tmp_path, extra_args=["--verbose", "--debug"])
+        cmd = agent._build_command(tmp_path, "j1")
+        assert "--verbose" in cmd
+        assert "--debug" in cmd
+
+    def test_build_skills_mount_returns_none_if_no_dir(self, tmp_path):
+        agent = self._make_agent(tmp_path, skills_source_dir=tmp_path / "nodir")
+        assert agent._build_skills_mount() is None
+
+    def test_build_skills_mount_returns_none_if_empty(self, tmp_path):
+        skills = tmp_path / "skills"
+        skills.mkdir()
+        agent = self._make_agent(tmp_path, skills_source_dir=skills)
+        assert agent._build_skills_mount() is None
+
+    def test_build_skills_mount_returns_dict_with_content(self, tmp_path):
+        skills = tmp_path / "skills"
+        skills.mkdir()
+        (skills / "my_skill.md").write_text("skill content")
+        agent = self._make_agent(tmp_path, skills_source_dir=skills)
+        mount = agent._build_skills_mount()
+        assert mount is not None
+        assert mount["type"] == "bind"
+        assert mount["target"] == "/skills"
+        assert mount["read_only"] is True
+
+    def test_build_command_includes_mounts_when_skills_exist(self, tmp_path):
+        skills = tmp_path / "skills"
+        skills.mkdir()
+        (skills / "s.md").write_text("x")
+        agent = self._make_agent(tmp_path, skills_source_dir=skills)
+        cmd = agent._build_command(tmp_path, "j1")
+        assert "--mounts-json" in cmd
+        assert "--ak" in cmd
+
+    def test_read_reward_from_result_json(self, tmp_path):
+        agent = self._make_agent(tmp_path)
+        job_dir = tmp_path / "job"
+        job_dir.mkdir()
+        result = {"verifier_result": {"rewards": {"reward": 0.8}}}
+        (job_dir / "result.json").write_text(json.dumps(result))
+        reward, status = agent._read_reward(job_dir)
+        assert reward == 0.8
+        assert status == "verified"
+
+    def test_read_reward_from_reward_txt(self, tmp_path):
+        agent = self._make_agent(tmp_path)
+        job_dir = tmp_path / "job"
+        verifier = job_dir / "verifier"
+        verifier.mkdir(parents=True)
+        (verifier / "reward.txt").write_text("0.5")
+        reward, status = agent._read_reward(job_dir)
+        assert reward == 0.5
+        assert status == "verified"
+
+    def test_read_reward_from_reward_json(self, tmp_path):
+        agent = self._make_agent(tmp_path)
+        job_dir = tmp_path / "job"
+        verifier = job_dir / "verifier"
+        verifier.mkdir(parents=True)
+        (verifier / "reward.json").write_text(json.dumps({"score": 0.9}))
+        reward, status = agent._read_reward(job_dir)
+        assert reward == 0.9
+        assert status == "verified"
+
+    def test_read_reward_returns_none_for_missing_dir(self, tmp_path):
+        agent = self._make_agent(tmp_path)
+        reward, status = agent._read_reward(tmp_path / "nonexistent")
+        assert reward is None
+        assert status == "no_job_dir"
+
+    def test_read_reward_returns_none_for_empty_dir(self, tmp_path):
+        agent = self._make_agent(tmp_path)
+        job_dir = tmp_path / "empty_job"
+        job_dir.mkdir()
+        reward, status = agent._read_reward(job_dir)
+        assert reward is None
+        assert status == "no_reward"
+
+    def test_run_unknown_task_returns_error_trace(self, tmp_path):
+        agent = self._make_agent(tmp_path)
+        with patch("src.api.harbor_loader.TASK_PATH_INDEX", {}):
+            trace = asyncio.run(agent.run("nonexistent/task"))
+        assert trace.is_error
+        assert "unknown harbor task id" in trace.result
+
+    def test_run_missing_task_toml_returns_error_trace(self, tmp_path):
+        from src.api.harbor_loader import TASK_PATH_INDEX
+        agent = self._make_agent(tmp_path)
+        empty_dir = tmp_path / "no_toml"
+        empty_dir.mkdir()
+        with patch.dict(TASK_PATH_INDEX, {"org/t1": empty_dir}, clear=True):
+            trace = asyncio.run(agent.run("org/t1"))
+        assert trace.is_error
+        assert "no task.toml" in trace.result
+
+    def test_error_trace_has_zero_reward_envelope(self, tmp_path):
+        agent = self._make_agent(tmp_path)
+        with patch("src.api.harbor_loader.TASK_PATH_INDEX", {}):
+            trace = asyncio.run(agent.run("bad/task"))
+        envelope = json.loads(trace.output.final_answer)
+        assert envelope["reward"] == 0.0
+        assert envelope["exit_status"] == "error"
+
+
+# ── Config validation ────────────────────────────────────────────────────────
+
+
+class TestHarborConfigValidation:
+
+    def test_harbor_tasks_root_path_absolute(self, tmp_path):
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root="/absolute/path")
+        assert cfg.harbor_tasks_root_path == Path("/absolute/path")
+
+    def test_harbor_tasks_root_path_relative(self, tmp_path):
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root="rel/tasks")
+        assert cfg.harbor_tasks_root_path == tmp_path / "rel/tasks"
+
+    def test_harbor_tasks_root_path_docker_override(self, tmp_path):
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root="local/tasks")
+        overrides = json.dumps({"harbor_tasks_root": "/mnt/harbor_tasks"})
+        with patch.dict("os.environ", {"EVOSKILL_PATH_OVERRIDES": overrides}):
+            assert cfg.harbor_tasks_root_path == Path("/mnt/harbor_tasks")
+
+    def test_make_scorer_returns_harbor_scorer(self, tmp_path):
+        from src.cli.shared import make_scorer
+        cfg = _make_harbor_cfg(tmp_path)
+        scorer = make_scorer(cfg)
+        from src.evaluation.harbor_scorer import harbor_reward_scorer
+        assert scorer is harbor_reward_scorer
+
+
+# ── Docker launcher harbor support ───────────────────────────────────────────
+
+
+class TestDockerHarbor:
+
+    def test_compose_skips_csv_mount_for_harbor(self, tmp_path):
+        from src.docker.launcher import _build_compose
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(tmp_path / "tasks"))
+        (tmp_path / ".evoskill").mkdir(exist_ok=True)
+        compose = _build_compose(cfg, [])
+        volumes = compose["services"]["evoskill"]["volumes"]
+        assert not any("/mnt/dataset" in v for v in volumes)
+
+    def test_compose_mounts_external_harbor_tasks(self, tmp_path):
+        from src.docker.launcher import _build_compose
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".evoskill").mkdir()
+        ext_tasks = tmp_path / "external_tasks"
+        ext_tasks.mkdir()
+        cfg = _make_harbor_cfg(project, harbor_tasks_root=str(ext_tasks))
+        compose = _build_compose(cfg, [])
+        volumes = compose["services"]["evoskill"]["volumes"]
+        assert any("/mnt/harbor_tasks" in v for v in volumes)
+
+    def test_compose_sets_harbor_path_override(self, tmp_path):
+        from src.docker.launcher import _build_compose
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".evoskill").mkdir()
+        ext_tasks = tmp_path / "external_tasks"
+        ext_tasks.mkdir()
+        cfg = _make_harbor_cfg(project, harbor_tasks_root=str(ext_tasks))
+        compose = _build_compose(cfg, [])
+        env = compose["services"]["evoskill"]["env_with_values"]
+        override_str = [e for e in env if "EVOSKILL_PATH_OVERRIDES" in e]
+        assert override_str
+        overrides = json.loads(override_str[0].split("=", 1)[1])
+        assert overrides["harbor_tasks_root"] == "/mnt/harbor_tasks"
+
+    def test_compose_no_mount_for_internal_harbor_tasks(self, tmp_path):
+        from src.docker.launcher import _build_compose
+        (tmp_path / ".evoskill").mkdir(exist_ok=True)
+        tasks = tmp_path / "tasks"
+        tasks.mkdir()
+        cfg = _make_harbor_cfg(tmp_path, harbor_tasks_root=str(tasks))
+        compose = _build_compose(cfg, [])
+        volumes = compose["services"]["evoskill"]["volumes"]
+        assert not any("/mnt/harbor_tasks" in v for v in volumes)
+
+
+# ── Init harbor → harness mapping ────────────────────────────────────────────
+
+
+class TestInitHarborMapping:
+
+    def test_harness_to_harbor_agent_mapping(self):
+        from src.cli.commands.init import _HARNESS_TO_HARBOR_AGENT
+        assert _HARNESS_TO_HARBOR_AGENT["claude"] == "claude-code"
+        assert _HARNESS_TO_HARBOR_AGENT["opencode"] == "opencode"
+        assert _HARNESS_TO_HARBOR_AGENT["codex"] == "codex"
+        assert _HARNESS_TO_HARBOR_AGENT["goose"] == "goose"
+        assert _HARNESS_TO_HARBOR_AGENT["openhands"] == "openhands"
+
+    def test_write_config_harbor_auto_derives_inner_agent(self, tmp_path):
+        from src.cli.commands.init import _write_config
+        import tomllib
+        path = tmp_path / "config.toml"
+        _write_config(path, {
+            "harness": "claude",
+            "dataset_source": "harbor",
+            "dataset_path": "",
+            "question_col": "",
+            "gt_col": "",
+            "category_col": "",
+            "data_dirs": [],
+            "execution": "local",
+            "remote": None,
+            "harbor_tasks_root": "/some/path",
+        })
+        with open(path, "rb") as f:
+            raw = tomllib.load(f)
+        assert raw["harbor"]["inner_agent"] == "claude-code"
+        assert raw["harbor"]["enabled"] is True
+        assert raw["scorer"]["type"] == "harbor"
+        assert raw["dataset"]["source"] == "harbor"
+
+    def test_write_config_harbor_env_daytona(self, tmp_path):
+        from src.cli.commands.init import _write_config
+        import tomllib
+        path = tmp_path / "config.toml"
+        _write_config(path, {
+            "harness": "opencode",
+            "dataset_source": "harbor",
+            "dataset_path": "",
+            "question_col": "",
+            "gt_col": "",
+            "category_col": "",
+            "data_dirs": [],
+            "execution": "daytona",
+            "remote": None,
+            "harbor_tasks_root": "/tasks",
+        })
+        with open(path, "rb") as f:
+            raw = tomllib.load(f)
+        assert raw["harbor"]["env"] == "daytona"
+        assert raw["harbor"]["inner_agent"] == "opencode"
+
+    def test_write_config_csv_mode_no_harbor_section(self, tmp_path):
+        from src.cli.commands.init import _write_config
+        import tomllib
+        path = tmp_path / "config.toml"
+        _write_config(path, {
+            "harness": "claude",
+            "dataset_source": "csv",
+            "dataset_path": "/data.csv",
+            "question_col": "q",
+            "gt_col": "a",
+            "category_col": "cat",
+            "data_dirs": [],
+            "execution": "local",
+            "remote": None,
+            "harbor_tasks_root": "",
+        })
+        with open(path, "rb") as f:
+            raw = tomllib.load(f)
+        assert "harbor" not in raw
+        assert raw["dataset"]["source"] == "csv"

--- a/uv.lock
+++ b/uv.lock
@@ -33,11 +33,11 @@ wheels = [
 
 [[package]]
 name = "aiofiles"
-version = "25.1.0"
+version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
 ]
 
 [[package]]
@@ -135,6 +135,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohttp-retry"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608, upload-time = "2024-11-06T10:44:54.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/99/84ba7273339d0f3dfa57901b846489d2e5c2cd731470167757f1935fffbd/aiohttp_retry-2.9.1-py3-none-any.whl", hash = "sha256:66d2759d1921838256a05a3f80ad7e724936f083e35be5abb5e16eed6be6dc54", size = 9981, upload-time = "2024-11-06T10:44:52.917Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -159,6 +171,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/a6/74c8cadc2882977d80ad756a13857857dbcf9bd405bc80b662eb10651282/alembic-1.17.2.tar.gz", hash = "sha256:bbe9751705c5e0f14877f02d46c53d10885e377e3d90eda810a016f9baa19e8e", size = 1988064, upload-time = "2025-11-14T20:35:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/88/6237e97e3385b57b5f1528647addea5cc03d4d65d5979ab24327d41fb00d/alembic-1.17.2-py3-none-any.whl", hash = "sha256:f483dd1fe93f6c5d49217055e4d15b905b425b6af906746abb35b69c1996c4e6", size = 248554, upload-time = "2025-11-14T20:35:05.699Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
 ]
 
 [[package]]
@@ -971,6 +992,97 @@ wheels = [
 ]
 
 [[package]]
+name = "daytona"
+version = "0.172.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "daytona-api-client" },
+    { name = "daytona-api-client-async" },
+    { name = "daytona-toolbox-api-client" },
+    { name = "daytona-toolbox-api-client-async" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "obstore" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-aiohttp-client" },
+    { name = "opentelemetry-sdk" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
+    { name = "toml" },
+    { name = "urllib3" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/72/5b399e2e32b6b2074baf24ef59ca34697431e8ff5ce8924c5c5ff467bfba/daytona-0.172.0.tar.gz", hash = "sha256:d810cdc8756ca6989fa9e73d3912969c32ea2cb6e2c57aa3810403532cd8530b", size = 126021, upload-time = "2026-05-05T17:39:39.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/7a/82bbeb497f0a2b0e85e90fcb1fdbdcfcd7ca538fe25608884b0d89748f91/daytona-0.172.0-py3-none-any.whl", hash = "sha256:3c8dc3b5f9f850d8566a098c78700ff8cc22c7aca4c007bee862e6c0307f92fb", size = 155321, upload-time = "2026-05-05T17:39:37.69Z" },
+]
+
+[[package]]
+name = "daytona-api-client"
+version = "0.172.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/b7/f1e0289e7b90ecfa871be1d75b58d552bcbf307f827ffd2ef633beead04f/daytona_api_client-0.172.0.tar.gz", hash = "sha256:05c2ec4d7996007694a311a7f7cac5acda43a1901531edbb4841100fb08fadcc", size = 148169, upload-time = "2026-05-05T17:38:16.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/b9/20640d65dd95c052f59f79872cb7beece7a37f5ee479ff570f8c43039c2d/daytona_api_client-0.172.0-py3-none-any.whl", hash = "sha256:b24d23612146e1f8091e516c824caf9cb88753dba622502382534b4e08a822f1", size = 408002, upload-time = "2026-05-05T17:38:14.716Z" },
+]
+
+[[package]]
+name = "daytona-api-client-async"
+version = "0.172.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/f8/ad015b38f1878259f221d6613c97a797320a0be2c76296422a8fa2b985bb/daytona_api_client_async-0.172.0.tar.gz", hash = "sha256:61fbdd8d5a328b997973d59d81a1a9afa2ae2782e426b06e6e4828b2447990d6", size = 148676, upload-time = "2026-05-05T17:39:03.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/6e/e26f231f3eed4d85e88871d52d0e66db9254a42761bfa13c6b2d8f975bac/daytona_api_client_async-0.172.0-py3-none-any.whl", hash = "sha256:1adc16d5fa5c782aafb84de4a8f063cff7e4d7ddb95d25d1fe0d4da6de07cf72", size = 411244, upload-time = "2026-05-05T17:39:02.119Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client"
+version = "0.172.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/40/3646b18a29a0c163e75bd9f65115a6f8f51ac9e93df86be7a1deadbfcc1a/daytona_toolbox_api_client-0.172.0.tar.gz", hash = "sha256:cd7057e0e68c82f87aba76524e3cf1ef276a8cc629da933b2658a1b94de30e28", size = 74030, upload-time = "2026-05-05T17:38:45.954Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/91/7d013676d47d3713c88a85ef6a76a8dfe2cefbd300c90e6babee12062dd2/daytona_toolbox_api_client-0.172.0-py3-none-any.whl", hash = "sha256:c19c2df19805eda16a6230001a344139d17cced6b5ef41558b14ca236cb2e85d", size = 191439, upload-time = "2026-05-05T17:38:44.325Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client-async"
+version = "0.172.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/3f/238692cf8efb5517426ffbd500b46df2d3e4345e3fe7e94e5e319b3b8353/daytona_toolbox_api_client_async-0.172.0.tar.gz", hash = "sha256:7402ba601660891b39fc09669f6409d3b621edc5015bd8ccf65ad874809cf377", size = 67550, upload-time = "2026-05-05T17:38:59.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/52/6485dd58c9339b8bc53f56b0dee1937028668e4b4e3f7cd72d44afe872c0/daytona_toolbox_api_client_async-0.172.0-py3-none-any.whl", hash = "sha256:b26051a08e07fc4560ca68379f73e67babe6a244e9ec8f557b5a4f0e63cc9a38", size = 189565, upload-time = "2026-05-05T17:38:57.956Z" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1010,6 +1122,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1028,6 +1152,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/80/630b4b88364e9a8c8c5797f4602d0f76ef820909ee32f0bacb9f90654042/dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0", size = 186976, upload-time = "2025-04-16T00:41:48.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049", size = 119668, upload-time = "2025-04-16T00:41:47.671Z" },
+]
+
+[[package]]
+name = "dirhash"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "scantree" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/70/49f93897f3a4f7ab5f20a854ebc91aad47854e9fb2cd169e3a4452fa3f5e/dirhash-0.5.0.tar.gz", hash = "sha256:e60760f0ab2e935d8cb088923ea2c6492398dca42cec785df778985fd4cd5386", size = 21377, upload-time = "2024-08-03T22:14:13.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/1f/c8bf92552b7f0a13b9f12b85e3de8df6d9814240e0f8ce8f37433df028b3/dirhash-0.5.0-py3-none-any.whl", hash = "sha256:523dfd6b058c64f45b31604376926c6e2bd2ea301d0df23095d4055674e38b09", size = 13119, upload-time = "2024-08-03T22:14:11.688Z" },
 ]
 
 [[package]]
@@ -1143,28 +1279,38 @@ source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },
     { name = "click" },
-    { name = "datasets" },
-    { name = "dspy" },
-    { name = "ipykernel" },
-    { name = "ipywidgets" },
-    { name = "llm-sandbox", extra = ["docker"] },
-    { name = "nbformat" },
-    { name = "notebook" },
+    { name = "daytona" },
+    { name = "harbor" },
+    { name = "hatchling" },
+    { name = "httpx" },
     { name = "openai-codex-sdk" },
     { name = "opencode-ai" },
     { name = "openhands-sdk" },
     { name = "openhands-tools" },
     { name = "pandas" },
-    { name = "pip" },
-    { name = "plotly" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "questionary" },
     { name = "rich" },
-    { name = "seaborn" },
     { name = "tomli-w" },
+    { name = "tqdm" },
+]
+
+[package.optional-dependencies]
+eval = [
+    { name = "datasets" },
+    { name = "dspy" },
+    { name = "llm-sandbox", extra = ["docker"] },
     { name = "torch" },
+]
+notebooks = [
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "nbformat" },
+    { name = "notebook" },
+    { name = "plotly" },
+    { name = "seaborn" },
 ]
 
 [package.dev-dependencies]
@@ -1177,29 +1323,34 @@ dev = [
 requires-dist = [
     { name = "claude-agent-sdk", specifier = ">=0.1.16" },
     { name = "click", specifier = ">=8.1.8" },
-    { name = "datasets", specifier = ">=4.6.0" },
-    { name = "dspy", specifier = ">=3.0.4" },
-    { name = "ipykernel", specifier = ">=7.1.0" },
-    { name = "ipywidgets", specifier = ">=8.1.8" },
-    { name = "llm-sandbox", extras = ["docker"], specifier = ">=0.3.36" },
-    { name = "nbformat", specifier = ">=5.10.4" },
-    { name = "notebook", specifier = ">=7.5.3" },
+    { name = "datasets", marker = "extra == 'eval'", specifier = ">=4.6.0" },
+    { name = "daytona", specifier = ">=0.1.0" },
+    { name = "dspy", marker = "extra == 'eval'", specifier = ">=3.0.4" },
+    { name = "harbor", specifier = ">=0.6.1" },
+    { name = "hatchling" },
+    { name = "httpx", specifier = ">=0.23.0" },
+    { name = "ipykernel", marker = "extra == 'notebooks'", specifier = ">=7.1.0" },
+    { name = "ipywidgets", marker = "extra == 'notebooks'", specifier = ">=8.1.8" },
+    { name = "llm-sandbox", extras = ["docker"], marker = "extra == 'eval'", specifier = ">=0.3.36" },
+    { name = "nbformat", marker = "extra == 'notebooks'", specifier = ">=5.10.4" },
+    { name = "notebook", marker = "extra == 'notebooks'", specifier = ">=7.5.3" },
     { name = "openai-codex-sdk", specifier = ">=0.1.11" },
     { name = "opencode-ai", specifier = ">=0.1.0a36" },
     { name = "openhands-sdk", specifier = ">=1.16.1" },
     { name = "openhands-tools", specifier = ">=1.16.1" },
     { name = "pandas", specifier = ">=2.3.3" },
-    { name = "pip", specifier = ">=26.0.1" },
-    { name = "plotly", specifier = ">=6.5.2" },
+    { name = "plotly", marker = "extra == 'notebooks'", specifier = ">=6.5.2" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "questionary", specifier = ">=2.1.1" },
     { name = "rich", specifier = ">=14.2.0" },
-    { name = "seaborn", specifier = ">=0.13.2" },
+    { name = "seaborn", marker = "extra == 'notebooks'", specifier = ">=0.13.2" },
     { name = "tomli-w", specifier = ">=1.2.0" },
-    { name = "torch", specifier = ">=2.9.1" },
+    { name = "torch", marker = "extra == 'eval'", specifier = ">=2.9.1" },
+    { name = "tqdm", specifier = ">=4.60.0" },
 ]
+provides-extras = ["eval", "notebooks"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1244,6 +1395,22 @@ wheels = [
 [package.optional-dependencies]
 lua = [
     { name = "lupa" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -1750,6 +1917,66 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "harbor"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "claude-agent-sdk" },
+    { name = "datasets" },
+    { name = "dirhash" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "litellm" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "ruff" },
+    { name = "shortuuid" },
+    { name = "supabase" },
+    { name = "tenacity" },
+    { name = "toml" },
+    { name = "typer" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/d0/6a191db74b63675e4e1746a2d28839567a82df62ad492a67a326efa5ac17/harbor-0.6.1.tar.gz", hash = "sha256:6418b584c3068c392b2d2bd3dc996629ad42524ea7a1260abcf5db94ae040ef0", size = 975530, upload-time = "2026-04-30T03:24:24.477Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/ec/b8cb6a7979fc5aa4eb20b5cc39d9709ffc4c84bc4429c3afb400a571f9fb/harbor-0.6.1-py3-none-any.whl", hash = "sha256:9b77b7d413329c1c06af3decdecc38bdd6eb483796250473ee0225be35301cbb", size = 1106106, upload-time = "2026-04-30T03:24:26.339Z" },
+]
+
+[[package]]
+name = "hatchling"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/9c/b4cfe330cd4f49cff17fd771154730555fa4123beb7f292cf0098b4e6c20/hatchling-1.29.0.tar.gz", hash = "sha256:793c31816d952cee405b83488ce001c719f325d9cda69f1fc4cd750527640ea6", size = 55656, upload-time = "2026-02-23T19:42:06.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl", hash = "sha256:50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0", size = 76356, upload-time = "2026-02-23T19:42:05.197Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1776,6 +2003,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
     { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
     { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -1819,6 +2055,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
 socks = [
     { name = "socksio" },
 ]
@@ -1851,6 +2090,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/51/6db95c854e5eb3af8e0edfbfad7588983f63be39662054a49d5e116fb65d/huggingface_hub-1.2.2.tar.gz", hash = "sha256:b5b97bd37f4fe5b898a467373044649c94ee32006c032ce8fb835abe9d92ea28", size = 614598, upload-time = "2025-12-10T14:51:50.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/40/eb2f3a2c09bebf2fc989ba8bf701ce1f56b2f054b51e1a0fcb3e5d23f13a/huggingface_hub-1.2.2-py3-none-any.whl", hash = "sha256:0f55d7d22058fbf8b29d8095aeee80a7b695aa764f906a21e886c1f87223718f", size = 520964, upload-time = "2025-12-10T14:51:48.206Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -2901,6 +3149,88 @@ wheels = [
 ]
 
 [[package]]
+name = "mmh3"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/1a/edb23803a168f070ded7a3014c6d706f63b90c84ccc024f89d794a3b7a6d/mmh3-5.2.1.tar.gz", hash = "sha256:bbea5b775f0ac84945191fb83f845a6fd9a21a03ea7f2e187defac7e401616ad", size = 33775, upload-time = "2026-03-05T15:55:57.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/94/bc5c3b573b40a328c4d141c20e399039ada95e5e2a661df3425c5165fd84/mmh3-5.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0cc21533878e5586b80d74c281d7f8da7932bc8ace50b8d5f6dbf7e3935f63f1", size = 56087, upload-time = "2026-03-05T15:54:21.92Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/80/64a02cc3e95c3af0aaa2590849d9ed24a9f14bb93537addde688e039b7c3/mmh3-5.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4eda76074cfca2787c8cf1bec603eaebdddd8b061ad5502f85cddae998d54f00", size = 40500, upload-time = "2026-03-05T15:54:22.953Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/e6d6602ce18adf4ddcd0e48f2e13590cc92a536199e52109f46f259d3c46/mmh3-5.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eee884572b06bbe8a2b54f424dbd996139442cf83c76478e1ec162512e0dd2c7", size = 40034, upload-time = "2026-03-05T15:54:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c2/bf4537a8e58e21886ef16477041238cab5095c836496e19fafc34b7445d2/mmh3-5.2.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0d0b7e803191db5f714d264044e06189c8ccd3219e936cc184f07106bd17fd7b", size = 97292, upload-time = "2026-03-05T15:54:25.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e2/51ed62063b44d10b06d975ac87af287729eeb5e3ed9772f7584a17983e90/mmh3-5.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e6c219e375f6341d0959af814296372d265a8ca1af63825f65e2e87c618f006", size = 103274, upload-time = "2026-03-05T15:54:26.44Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ce/12a7524dca59eec92e5b31fdb13ede1e98eda277cf2b786cf73bfbc24e81/mmh3-5.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26fb5b9c3946bf7f1daed7b37e0c03898a6f062149127570f8ede346390a0825", size = 106158, upload-time = "2026-03-05T15:54:28.578Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1f/d3ba6dd322d01ab5d44c46c8f0c38ab6bbbf9b5e20e666dfc05bf4a23604/mmh3-5.2.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3c38d142c706201db5b2345166eeef1e7740e3e2422b470b8ba5c8727a9b4c7a", size = 113005, upload-time = "2026-03-05T15:54:29.767Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a9/15d6b6f913294ea41b44d901741298e3718e1cb89ee626b3694625826a43/mmh3-5.2.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50885073e2909251d4718634a191c49ae5f527e5e1736d738e365c3e8be8f22b", size = 120744, upload-time = "2026-03-05T15:54:30.931Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/70b73923fd0284c439860ff5c871b20210dfdbe9a6b9dd0ee6496d77f174/mmh3-5.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b3f99e1756fc48ad507b95e5d86f2fb21b3d495012ff13e6592ebac14033f166", size = 99111, upload-time = "2026-03-05T15:54:32.353Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/38/99f7f75cd27d10d8b899a1caafb9d531f3903e4d54d572220e3d8ac35e89/mmh3-5.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62815d2c67f2dd1be76a253d88af4e1da19aeaa1820146dec52cf8bee2958b16", size = 98623, upload-time = "2026-03-05T15:54:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/68/6e292c0853e204c44d2f03ea5f090be3317a0e2d9417ecb62c9eb27687df/mmh3-5.2.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8f767ba0911602ddef289404e33835a61168314ebd3c729833db2ed685824211", size = 106437, upload-time = "2026-03-05T15:54:35.177Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/fedd7284c459cfb58721d461fcf5607a4c1f5d9ab195d113d51d10164d16/mmh3-5.2.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:67e41a497bac88cc1de96eeba56eeb933c39d54bc227352f8455aa87c4ca4000", size = 110002, upload-time = "2026-03-05T15:54:36.673Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ac/ca8e0c19a34f5b71390171d2ff0b9f7f187550d66801a731bb68925126a4/mmh3-5.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d74a03fb57757ece25aa4b3c1c60157a1cece37a020542785f942e2f827eed5", size = 97507, upload-time = "2026-03-05T15:54:37.804Z" },
+    { url = "https://files.pythonhosted.org/packages/df/94/6ebb9094cfc7ac5e7950776b9d13a66bb4a34f83814f32ba2abc9494fc68/mmh3-5.2.1-cp312-cp312-win32.whl", hash = "sha256:7374d6e3ef72afe49697ecd683f3da12f4fc06af2d75433d0580c6746d2fa025", size = 40773, upload-time = "2026-03-05T15:54:40.077Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/cd3527198cf159495966551c84a5f36805a10ac17b294f41f67b83f6a4d6/mmh3-5.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:3a9fed49c6ce4ed7e73f13182760c65c816da006debe67f37635580dfb0fae00", size = 41560, upload-time = "2026-03-05T15:54:41.148Z" },
+    { url = "https://files.pythonhosted.org/packages/15/96/6fe5ebd0f970a076e3ed5512871ce7569447b962e96c125528a2f9724470/mmh3-5.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:bbfcb95d9a744e6e2827dfc66ad10e1020e0cac255eb7f85652832d5a264c2fc", size = 39313, upload-time = "2026-03-05T15:54:42.171Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a5/9daa0508a1569a54130f6198d5462a92deda870043624aa3ea72721aa765/mmh3-5.2.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:723b2681ed4cc07d3401bbea9c201ad4f2a4ca6ba8cddaff6789f715dd2b391e", size = 40832, upload-time = "2026-03-05T15:54:43.212Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6b/3230c6d80c1f4b766dedf280a92c2241e99f87c1504ff74205ec8cebe451/mmh3-5.2.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:3619473a0e0d329fd4aec8075628f8f616be2da41605300696206d6f36920c3d", size = 41964, upload-time = "2026-03-05T15:54:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/62/fb/648bfddb74a872004b6ee751551bfdda783fe6d70d2e9723bad84dbe5311/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:e48d4dbe0f88e53081da605ae68644e5182752803bbc2beb228cca7f1c4454d6", size = 39114, upload-time = "2026-03-05T15:54:45.205Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c2/ab7901f87af438468b496728d11264cb397b3574d41506e71b92128e0373/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a482ac121de6973897c92c2f31defc6bafb11c83825109275cffce54bb64933f", size = 39819, upload-time = "2026-03-05T15:54:46.509Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ed/6f88dda0df67de1612f2e130ffea34cf84aaee5bff5b0aff4dbff2babe34/mmh3-5.2.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:17fbb47f0885ace8327ce1235d0416dc86a211dcd8cc1e703f41523be32cfec8", size = 40330, upload-time = "2026-03-05T15:54:47.864Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/66/7516d23f53cdf90f43fce24ab80c28f45e6851d78b46bef8c02084edf583/mmh3-5.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d51fde50a77f81330523562e3c2734ffdca9c4c9e9d355478117905e1cfe16c6", size = 56078, upload-time = "2026-03-05T15:54:48.9Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/34/4d152fdf4a91a132cb226b671f11c6b796eada9ab78080fb5ce1e95adaab/mmh3-5.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:19bbd3b841174ae6ed588536ab5e1b1fe83d046e668602c20266547298d939a9", size = 40498, upload-time = "2026-03-05T15:54:49.942Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4c/8e3af1b6d85a299767ec97bd923f12b06267089c1472c27c1696870d1175/mmh3-5.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be77c402d5e882b6fbacfd90823f13da8e0a69658405a39a569c6b58fdb17b03", size = 40033, upload-time = "2026-03-05T15:54:50.994Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/966ea560e32578d453c9e9db53d602cbb1d0da27317e232afa7c38ceba11/mmh3-5.2.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fd96476f04db5ceba1cfa0f21228f67c1f7402296f0e73fee3513aa680ad237b", size = 97320, upload-time = "2026-03-05T15:54:52.072Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/0d/2c5f9893b38aeb6b034d1a44ecd55a010148054f6a516abe53b5e4057297/mmh3-5.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:707151644085dd0f20fe4f4b573d28e5130c4aaa5f587e95b60989c5926653b5", size = 103299, upload-time = "2026-03-05T15:54:53.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fc/2ebaef4a4d4376f89761274dc274035ffd96006ab496b4ee5af9b08f21a9/mmh3-5.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3737303ca9ea0f7cb83028781148fcda4f1dac7821db0c47672971dabcf63593", size = 106222, upload-time = "2026-03-05T15:54:55.092Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/ea7ffe126d0ba0406622602a2d05e1e1a6841cc92fc322eb576c95b27fad/mmh3-5.2.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2778fed822d7db23ac5008b181441af0c869455b2e7d001f4019636ac31b6fe4", size = 113048, upload-time = "2026-03-05T15:54:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/85/57/9447032edf93a64aa9bef4d9aa596400b1756f40411890f77a284f6293ca/mmh3-5.2.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d57dea657357230cc780e13920d7fa7db059d58fe721c80020f94476da4ca0a1", size = 120742, upload-time = "2026-03-05T15:54:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/53/82/a86cc87cc88c92e9e1a598fee509f0409435b57879a6129bf3b3e40513c7/mmh3-5.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:169e0d178cb59314456ab30772429a802b25d13227088085b0d49b9fe1533104", size = 99132, upload-time = "2026-03-05T15:54:58.583Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f7/6b16eb1b40ee89bb740698735574536bc20d6cdafc65ae702ea235578e05/mmh3-5.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7e4e1f580033335c6f76d1e0d6b56baf009d1a64d6a4816347e4271ba951f46d", size = 98686, upload-time = "2026-03-05T15:55:00.078Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/88/a601e9f32ad1410f438a6d0544298ea621f989bd34a0731a7190f7dec799/mmh3-5.2.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2bd9f19f7f1fcebd74e830f4af0f28adad4975d40d80620be19ffb2b2af56c9f", size = 106479, upload-time = "2026-03-05T15:55:01.532Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/ce29ae3dfc4feec4007a437a1b7435fb9507532a25147602cd5b52be86db/mmh3-5.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c88653877aeb514c089d1b3d473451677b8b9a6d1497dbddf1ae7934518b06d2", size = 110030, upload-time = "2026-03-05T15:55:02.934Z" },
+    { url = "https://files.pythonhosted.org/packages/13/30/ae444ef2ff87c805d525da4fa63d27cda4fe8a48e77003a036b8461cfd5c/mmh3-5.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fceef7fe67c81e1585198215e42ad3fdba3a25644beda8fbdaf85f4d7b93175a", size = 97536, upload-time = "2026-03-05T15:55:04.135Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f9/dc3787ee5c813cc27fe79f45ad4500d9b5437f23a7402435cc34e07c7718/mmh3-5.2.1-cp313-cp313-win32.whl", hash = "sha256:54b64fb2433bc71488e7a449603bf8bd31fbcf9cb56fbe1eb6d459e90b86c37b", size = 40769, upload-time = "2026-03-05T15:55:05.277Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/850e0b5a1e97799822ebfc4ca0e8c6ece3ed8baf7dcdf64de817dfdda2ca/mmh3-5.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:cae6383181f1e345317742d2ddd88f9e7d2682fa4c9432e3a74e47d92dce0229", size = 41563, upload-time = "2026-03-05T15:55:06.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/98c90b28e1da5458e19fbfaf4adb5289208d3bfccd45dd14eab216a2f0bb/mmh3-5.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:022aa1a528604e6c83d0a7705fdef0b5355d897a9e0fa3a8d26709ceaa06965d", size = 39310, upload-time = "2026-03-05T15:55:07.323Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b4/65bc1fb2bb7f83e91c30865023b1847cf89a5f237165575e8c83aa536584/mmh3-5.2.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:d771f085fcdf4035786adfb1d8db026df1eb4b41dac1c3d070d1e49512843227", size = 40794, upload-time = "2026-03-05T15:55:09.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/86/7168b3d83be8eb553897b1fac9da8bbb06568e5cfe555ffc329ebb46f59d/mmh3-5.2.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:7f196cd7910d71e9d9860da0ff7a77f64d22c1ad931f1dd18559a06e03109fc0", size = 41923, upload-time = "2026-03-05T15:55:10.924Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/b653ab611c9060ce8ff0ba25c0226757755725e789292f3ca138a58082cd/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b1f12bd684887a0a5d55e6363ca87056f361e45451105012d329b86ec19dbe0b", size = 39131, upload-time = "2026-03-05T15:55:11.961Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/5a2e0d34ab4d33543f01121e832395ea510132ea8e52cdf63926d9d81754/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:d106493a60dcb4aef35a0fac85105e150a11cf8bc2b0d388f5a33272d756c966", size = 39825, upload-time = "2026-03-05T15:55:13.013Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/69/81699a8f39a3f8d368bec6443435c0c392df0d200ad915bf0d222b588e03/mmh3-5.2.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:44983e45310ee5b9f73397350251cdf6e63a466406a105f1d16cb5baa659270b", size = 40344, upload-time = "2026-03-05T15:55:14.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b3/71c8c775807606e8fd8acc5c69016e1caf3200d50b50b6dd4b40ce10b76c/mmh3-5.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:368625fb01666655985391dbad3860dc0ba7c0d6b9125819f3121ee7292b4ac8", size = 56291, upload-time = "2026-03-05T15:55:15.137Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/75/2c24517d4b2ce9e4917362d24f274d3d541346af764430249ddcc4cb3a08/mmh3-5.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:72d1cc63bcc91e14933f77d51b3df899d6a07d184ec515ea7f56bff659e124d7", size = 40575, upload-time = "2026-03-05T15:55:16.518Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/e4a360164365ac9f07a25f0f7928e3a66eb9ecc989384060747aa170e6aa/mmh3-5.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e8b4b5580280b9265af3e0409974fb79c64cf7523632d03fbf11df18f8b0181e", size = 40052, upload-time = "2026-03-05T15:55:17.735Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ca/120d92223a7546131bbbc31c9174168ee7a73b1366f5463ffe69d9e691fe/mmh3-5.2.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4cbbde66f1183db040daede83dd86c06d663c5bb2af6de1142b7c8c37923dd74", size = 97311, upload-time = "2026-03-05T15:55:18.959Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/71/c1a60c1652b8813ef9de6d289784847355417ee0f2980bca002fe87f4ae5/mmh3-5.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8ff038d52ef6aa0f309feeba00c5095c9118d0abf787e8e8454d6048db2037fc", size = 103279, upload-time = "2026-03-05T15:55:20.448Z" },
+    { url = "https://files.pythonhosted.org/packages/48/29/ad97f4be1509cdcb28ae32c15593ce7c415db47ace37f8fad35b493faa9a/mmh3-5.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4130d0b9ce5fad6af07421b1aecc7e079519f70d6c05729ab871794eded8617", size = 106290, upload-time = "2026-03-05T15:55:21.6Z" },
+    { url = "https://files.pythonhosted.org/packages/77/29/1f86d22e281bd8827ba373600a4a8b0c0eae5ca6aa55b9a8c26d2a34decc/mmh3-5.2.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e0bfe77d238308839699944164b96a2eeccaf55f2af400f54dc20669d8d5f2", size = 113116, upload-time = "2026-03-05T15:55:22.826Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7c/339971ea7ed4c12d98f421f13db3ea576a9114082ccb59d2d1a0f00ccac1/mmh3-5.2.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f963eafc0a77a6c0562397da004f5876a9bcf7265a7bcc3205e29636bc4a1312", size = 120740, upload-time = "2026-03-05T15:55:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/3c7c4bdb8e926bb3c972d1e2907d77960c1c4b250b41e8366cf20c6e4373/mmh3-5.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:92883836caf50d5255be03d988d75bc93e3f86ba247b7ca137347c323f731deb", size = 99143, upload-time = "2026-03-05T15:55:25.456Z" },
+    { url = "https://files.pythonhosted.org/packages/df/0a/33dd8706e732458c8375eae63c981292de07a406bad4ec03e5269654aa2c/mmh3-5.2.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:57b52603e89355ff318025dd55158f6e71396c0f1f609d548e9ea9c94cc6ce0a", size = 98703, upload-time = "2026-03-05T15:55:26.723Z" },
+    { url = "https://files.pythonhosted.org/packages/51/04/76bbce05df76cbc3d396f13b2ea5b1578ef02b6a5187e132c6c33f99d596/mmh3-5.2.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f40a95186a72fa0b67d15fef0f157bfcda00b4f59c8a07cbe5530d41ac35d105", size = 106484, upload-time = "2026-03-05T15:55:28.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8f/c6e204a2c70b719c1f62ffd9da27aef2dddcba875ea9c31ca0e87b975a46/mmh3-5.2.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:58370d05d033ee97224c81263af123dea3d931025030fd34b61227a768a8858a", size = 110012, upload-time = "2026-03-05T15:55:29.532Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/37/7181efd8e39db386c1ebc3e6b7d1f702a09d7c1197a6f2742ed6b5c16597/mmh3-5.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7be6dfb49e48fd0a7d91ff758a2b51336f1cd21f9d44b20f6801f072bd080cdd", size = 97508, upload-time = "2026-03-05T15:55:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/42/0f/afa7ca2615fd85e1469474bb860e381443d0b868c083b62b41cb1d7ca32f/mmh3-5.2.1-cp314-cp314-win32.whl", hash = "sha256:54fe8518abe06a4c3852754bfd498b30cc58e667f376c513eac89a244ce781a4", size = 41387, upload-time = "2026-03-05T15:55:32.403Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0d/46d42a260ee1357db3d486e6c7a692e303c017968e14865e00efa10d09fc/mmh3-5.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:3f796b535008708846044c43302719c6956f39ca2d93f2edda5319e79a29efbb", size = 42101, upload-time = "2026-03-05T15:55:33.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7b/848a8378059d96501a41159fca90d6a99e89736b0afbe8e8edffeac8c74b/mmh3-5.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:cd471ede0d802dd936b6fab28188302b2d497f68436025857ca72cd3810423fe", size = 39836, upload-time = "2026-03-05T15:55:35.026Z" },
+    { url = "https://files.pythonhosted.org/packages/27/61/1dabea76c011ba8547c25d30c91c0ec22544487a8750997a27a0c9e1180b/mmh3-5.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5174a697ce042fa77c407e05efe41e03aa56dae9ec67388055820fb48cf4c3ba", size = 57727, upload-time = "2026-03-05T15:55:36.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/32/731185950d1cf2d5e28979cc8593016ba1619a295faba10dda664a4931b5/mmh3-5.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0a3984146e414684a6be2862d84fcb1035f4984851cb81b26d933bab6119bf00", size = 41308, upload-time = "2026-03-05T15:55:37.254Z" },
+    { url = "https://files.pythonhosted.org/packages/76/aa/66c76801c24b8c9418b4edde9b5e57c75e72c94e29c48f707e3962534f18/mmh3-5.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bd6e7d363aa93bd3421b30b6af97064daf47bc96005bddba67c5ffbc6df426b8", size = 40758, upload-time = "2026-03-05T15:55:38.61Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/bb/79a1f638a02f0ae389f706d13891e2fbf7d8c0a22ecde67ba828951bb60a/mmh3-5.2.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:113f78e7463a36dbbcea05bfe688efd7fa759d0f0c56e73c974d60dcfec3dfcc", size = 109670, upload-time = "2026-03-05T15:55:40.13Z" },
+    { url = "https://files.pythonhosted.org/packages/26/94/8cd0e187a288985bcfc79bf5144d1d712df9dee74365f59d26e3a1865be6/mmh3-5.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7e8ec5f606e0809426d2440e0683509fb605a8820a21ebd120dcdba61b74ef7f", size = 117399, upload-time = "2026-03-05T15:55:42.076Z" },
+    { url = "https://files.pythonhosted.org/packages/42/94/dfea6059bd5c5beda565f58a4096e43f4858fb6d2862806b8bbd12cbb284/mmh3-5.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22b0f9971ec4e07e8223f2beebe96a6cfc779d940b6f27d26604040dd74d3a44", size = 120386, upload-time = "2026-03-05T15:55:43.481Z" },
+    { url = "https://files.pythonhosted.org/packages/47/cb/f9c45e62aaa67220179f487772461d891bb582bb2f9783c944832c60efd9/mmh3-5.2.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:85ffc9920ffc39c5eee1e3ac9100c913a0973996fbad5111f939bbda49204bb7", size = 125924, upload-time = "2026-03-05T15:55:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/fe54a4a7c11bc9f623dfc1707decd034245602b076dfc1dcc771a4163170/mmh3-5.2.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7aec798c2b01aaa65a55f1124f3405804184373abb318a3091325aece235f67c", size = 135280, upload-time = "2026-03-05T15:55:45.866Z" },
+    { url = "https://files.pythonhosted.org/packages/97/67/fe7e9e9c143daddd210cd22aef89cbc425d58ecf238d2b7d9eb0da974105/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55dbbd8ffbc40d1697d5e2d0375b08599dae8746b0b08dea05eee4ce81648fac", size = 110050, upload-time = "2026-03-05T15:55:47.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c4/6d4b09fcbef80794de447c9378e39eefc047156b290fa3dd2d5257ca8227/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:6c85c38a279ca9295a69b9b088a2e48aa49737bb1b34e6a9dc6297c110e8d912", size = 111158, upload-time = "2026-03-05T15:55:48.239Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a6/ca51c864bdb30524beb055a6d8826db3906af0834ec8c41d097a6e8573d5/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:6290289fa5fb4c70fd7f72016e03633d60388185483ff3b162912c81205ae2cf", size = 116890, upload-time = "2026-03-05T15:55:49.405Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/04/5a1fe2e2ad843d03e89af25238cbc4f6840a8bb6c4329a98ab694c71deda/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:4fc6cd65dc4d2fdb2625e288939a3566e36127a84811a4913f02f3d5931da52d", size = 123121, upload-time = "2026-03-05T15:55:50.61Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4d/3c820c6f4897afd25905270a9f2330a23f77a207ea7356f7aadace7273c0/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:623f938f6a039536cc02b7582a07a080f13fdfd48f87e63201d92d7e34d09a18", size = 110187, upload-time = "2026-03-05T15:55:52.143Z" },
+    { url = "https://files.pythonhosted.org/packages/21/54/1d71cd143752361c0aebef16ad3f55926a6faf7b112d355745c1f8a25f7f/mmh3-5.2.1-cp314-cp314t-win32.whl", hash = "sha256:29bc3973676ae334412efdd367fcd11d036b7be3efc1ce2407ef8676dabfeb82", size = 41934, upload-time = "2026-03-05T15:55:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e4/63a2a88f31d93dea03947cccc2a076946857e799ea4f7acdecbf43b324aa/mmh3-5.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:28cfab66577000b9505a0d068c731aee7ca85cd26d4d63881fab17857e0fe1fb", size = 43036, upload-time = "2026-03-05T15:55:55.252Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0f/59204bf136d1201f8d7884cfbaf7498c5b4674e87a4c693f9bde63741ce1/mmh3-5.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dfd51b4c56b673dfbc43d7d27ef857dd91124801e2806c69bb45585ce0fa019b", size = 40391, upload-time = "2026-03-05T15:55:56.697Z" },
+]
+
+[[package]]
 name = "more-itertools"
 version = "11.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3351,6 +3681,55 @@ wheels = [
 ]
 
 [[package]]
+name = "obstore"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/8c/9ec984edd0f3b72226adfaa19b1c61b15823b35b52f311ca4af36d009d15/obstore-0.8.2.tar.gz", hash = "sha256:a467bc4e97169e2ba749981b4fd0936015428d9b8f3fb83a5528536b1b6f377f", size = 168852, upload-time = "2025-09-16T15:34:55.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/dc/60fefbb5736e69eab56657bca04ca64dc07fdeccb3814164a31b62ad066b/obstore-0.8.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bb70ce297a47392b1d9a3e310f18d59cd5ebbb9453428210fef02ed60e4d75d1", size = 3612955, upload-time = "2025-09-16T15:33:29.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8b/844e8f382e5a12b8a3796a05d76a03e12c7aedc13d6900419e39207d7868/obstore-0.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1619bf618428abf1f607e0b219b2e230a966dcf697b717deccfa0983dd91f646", size = 3346564, upload-time = "2025-09-16T15:33:30.698Z" },
+    { url = "https://files.pythonhosted.org/packages/89/73/8537f99e09a38a54a6a15ede907aa25d4da089f767a808f0b2edd9c03cec/obstore-0.8.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a4605c3ed7c9515aeb4c619b5f7f2c9986ed4a79fe6045e536b5e59b804b1476", size = 3460809, upload-time = "2025-09-16T15:33:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/99/7714dec721e43f521d6325a82303a002cddad089437640f92542b84e9cc8/obstore-0.8.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce42670417876dd8668cbb8659e860e9725e5f26bbc86449fd259970e2dd9d18", size = 3692081, upload-time = "2025-09-16T15:33:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/4ac4175fe95a24c220a96021c25c432bcc0c0212f618be0737184eebbaad/obstore-0.8.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4a3e893b2a06585f651c541c1972fe1e3bf999ae2a5fda052ee55eb7e6516f5", size = 3957466, upload-time = "2025-09-16T15:33:34.528Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/04/caa288fb735484fc5cb019bdf3d896eaccfae0ac4622e520d05692c46790/obstore-0.8.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08462b32f95a9948ed56ed63e88406e2e5a4cae1fde198f9682e0fb8487100ed", size = 3951293, upload-time = "2025-09-16T15:33:35.733Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2f/d380239da2d6a1fda82e17df5dae600a404e8a93a065784518ff8325d5f6/obstore-0.8.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a0bf7763292a8fc47d01cd66e6f19002c5c6ad4b3ed4e6b2729f5e190fa8a0d", size = 3766199, upload-time = "2025-09-16T15:33:36.904Z" },
+    { url = "https://files.pythonhosted.org/packages/28/41/d391be069d3da82969b54266948b2582aeca5dd735abeda4d63dba36e07b/obstore-0.8.2-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:bcd47f8126cb192cbe86942b8f73b1c45a651ce7e14c9a82c5641dfbf8be7603", size = 3529678, upload-time = "2025-09-16T15:33:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/4c/4862fdd1a3abde459ee8eea699b1797df638a460af235b18ca82c8fffb72/obstore-0.8.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:57eda9fd8c757c3b4fe36cf3918d7e589cc1286591295cc10b34122fa36dd3fd", size = 3698079, upload-time = "2025-09-16T15:33:39.696Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ca/014e747bc53b570059c27e3565b2316fbe5c107d4134551f4cd3e24aa667/obstore-0.8.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ea44442aad8992166baa69f5069750979e4c5d9ffce772e61565945eea5774b9", size = 3687154, upload-time = "2025-09-16T15:33:40.92Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/6db5f8edd93028e5b8bfbeee15e6bd3e56f72106107d31cb208b57659de4/obstore-0.8.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:41496a3ab8527402db4142aaaf0d42df9d7d354b13ba10d9c33e0e48dd49dd96", size = 3773444, upload-time = "2025-09-16T15:33:42.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e5/c9e2cc540689c873beb61246e1615d6e38301e6a34dec424f5a5c63c1afd/obstore-0.8.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:43da209803f052df96c7c3cbec512d310982efd2407e4a435632841a51143170", size = 3939315, upload-time = "2025-09-16T15:33:43.252Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c9/bb53280ca50103c1ffda373cdc9b0f835431060039c2897cbc87ddd92e42/obstore-0.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:1836f5dcd49f9f2950c75889ab5c51fb290d3ea93cdc39a514541e0be3af016e", size = 3978234, upload-time = "2025-09-16T15:33:44.393Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/5d/8c3316cc958d386d5e6ab03e9db9ddc27f8e2141cee4a6777ae5b92f3aac/obstore-0.8.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:212f033e53fe6e53d64957923c5c88949a400e9027f7038c705ec2e9038be563", size = 3612027, upload-time = "2025-09-16T15:33:45.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/4d/699359774ce6330130536d008bfc32827fab0c25a00238d015a5974a3d1d/obstore-0.8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bee21fa4ba148d08fa90e47a96df11161661ed31e09c056a373cb2154b0f2852", size = 3344686, upload-time = "2025-09-16T15:33:47.185Z" },
+    { url = "https://files.pythonhosted.org/packages/82/37/55437341f10512906e02fd9fa69a8a95ad3f2f6a916d3233fda01763d110/obstore-0.8.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4c66594b59832ff1ced4c72575d9beb8b5f9b4e404ac1150a42bfb226617fd50", size = 3459860, upload-time = "2025-09-16T15:33:48.382Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/51/4245a616c94ee4851965e33f7a563ab4090cc81f52cc73227ff9ceca2e46/obstore-0.8.2-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:089f33af5c2fe132d00214a0c1f40601b28f23a38e24ef9f79fb0576f2730b74", size = 3691648, upload-time = "2025-09-16T15:33:49.524Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f1/4e2fb24171e3ca3641a4653f006be826e7e17634b11688a5190553b00b83/obstore-0.8.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d87f658dfd340d5d9ea2d86a7c90d44da77a0db9e00c034367dca335735110cf", size = 3956867, upload-time = "2025-09-16T15:33:51.082Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f5/b703115361c798c9c1744e1e700d5908d904a8c2e2bd38bec759c9ffb469/obstore-0.8.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6e2e4fa92828c4fbc2d487f3da2d3588701a1b67d9f6ca3c97cc2afc912e9c63", size = 3950599, upload-time = "2025-09-16T15:33:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/53/20/08c6dc0f20c1394e2324b9344838e4e7af770cdcb52c30757a475f50daeb/obstore-0.8.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab440e89c5c37a8ec230857dd65147d4b923e0cada33297135d05e0f937d696a", size = 3765865, upload-time = "2025-09-16T15:33:53.291Z" },
+    { url = "https://files.pythonhosted.org/packages/77/20/77907765e29b2eba6bd8821872284d91170d7084f670855b2dfcb249ea14/obstore-0.8.2-cp313-cp313-manylinux_2_24_aarch64.whl", hash = "sha256:b9beed107c5c9cd995d4a73263861fcfbc414d58773ed65c14f80eb18258a932", size = 3529807, upload-time = "2025-09-16T15:33:54.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f5/f629d39cc30d050f52b1bf927e4d65c1cc7d7ffbb8a635cd546b5c5219a0/obstore-0.8.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b75b4e7746292c785e31edcd5aadc8b758238372a19d4c5e394db5c305d7d175", size = 3693629, upload-time = "2025-09-16T15:33:56.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ff/106763fd10f2a1cb47f2ef1162293c78ad52f4e73223d8d43fc6b755445d/obstore-0.8.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:f33e6c366869d05ab0b7f12efe63269e631c5450d95d6b4ba4c5faf63f69de70", size = 3686176, upload-time = "2025-09-16T15:33:57.247Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0c/d2ccb6f32feeca906d5a7c4255340df5262af8838441ca06c9e4e37b67d5/obstore-0.8.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:12c885a9ce5ceb09d13cc186586c0c10b62597eff21b985f6ce8ff9dab963ad3", size = 3773081, upload-time = "2025-09-16T15:33:58.475Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/79/40d1cc504cefc89c9b3dd8874287f3fddc7d963a8748d6dffc5880222013/obstore-0.8.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4accc883b93349a81c9931e15dd318cc703b02bbef2805d964724c73d006d00e", size = 3938589, upload-time = "2025-09-16T15:33:59.734Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/916c6777222db3271e9fb3cf9a97ed92b3a9b3e465bdeec96de9ab809d53/obstore-0.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:ec850adf9980e5788a826ccfd5819989724e2a2f712bfa3258e85966c8d9981e", size = 3977768, upload-time = "2025-09-16T15:34:01.25Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/61/66f8dc98bbf5613bbfe5bf21747b4c8091442977f4bd897945895ab7325c/obstore-0.8.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1431e40e9bb4773a261e51b192ea6489d0799b9d4d7dbdf175cdf813eb8c0503", size = 3623364, upload-time = "2025-09-16T15:34:02.957Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/66/6d527b3027e42f625c8fc816ac7d19b0d6228f95bfe7666e4d6b081d2348/obstore-0.8.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ddb39d4da303f50b959da000aa42734f6da7ac0cc0be2d5a7838b62c97055bb9", size = 3347764, upload-time = "2025-09-16T15:34:04.236Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/79/c00103302b620192ea447a948921ad3fed031ce3d19e989f038e1183f607/obstore-0.8.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e01f4e13783db453e17e005a4a3ceff09c41c262e44649ba169d253098c775e8", size = 3460981, upload-time = "2025-09-16T15:34:05.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d9/bfe4ed4b1aebc45b56644dd5b943cf8e1673505cccb352e66878a457e807/obstore-0.8.2-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:df0fc2d0bc17caff9b538564ddc26d7616f7e8b7c65b1a3c90b5048a8ad2e797", size = 3692711, upload-time = "2025-09-16T15:34:06.796Z" },
+    { url = "https://files.pythonhosted.org/packages/13/47/cd6c2cbb18e1f40c77e7957a4a03d2d83f1859a2e876a408f1ece81cad4c/obstore-0.8.2-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e439d06c99a140348f046c9f598ee349cc2dcd9105c15540a4b231f9cc48bbae", size = 3958362, upload-time = "2025-09-16T15:34:08.277Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ea/5ee82bf23abd71c7d6a3f2d008197ae8f8f569d41314c26a8f75318245be/obstore-0.8.2-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e37d9046669fcc59522d0faf1d105fcbfd09c84cccaaa1e809227d8e030f32c", size = 3957082, upload-time = "2025-09-16T15:34:09.477Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ee/46650405e50fdaa8d95f30375491f9c91fac9517980e8a28a4a6af66927f/obstore-0.8.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2646fdcc4bbe92dc2bb5bcdff15574da1211f5806c002b66d514cee2a23c7cb8", size = 3775539, upload-time = "2025-09-16T15:34:10.726Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/348a7ebebe2ca3d94dfc75344ea19675ae45472823e372c1852844078307/obstore-0.8.2-cp314-cp314-manylinux_2_24_aarch64.whl", hash = "sha256:e31a7d37675056d93dfc244605089dee67f5bba30f37c88436623c8c5ad9ba9d", size = 3535048, upload-time = "2025-09-16T15:34:12.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/07/b7a16cc0da91a4b902d47880ad24016abfe7880c63f7cdafda45d89a2f91/obstore-0.8.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:656313dd8170dde0f0cd471433283337a63912e8e790a121f7cc7639c83e3816", size = 3699035, upload-time = "2025-09-16T15:34:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/3269a3a58347e0b019742d888612c4b765293c9c75efa44e144b1e884c0d/obstore-0.8.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329038c9645d6d1741e77fe1a53e28a14b1a5c1461cfe4086082ad39ebabf981", size = 3687307, upload-time = "2025-09-16T15:34:14.501Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f9/4fd4819ad6a49d2f462a45be453561f4caebded0dc40112deeffc34b89b1/obstore-0.8.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1e4df99b369790c97c752d126b286dc86484ea49bff5782843a265221406566f", size = 3776076, upload-time = "2025-09-16T15:34:16.207Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/7c4f958fa0b9fc4778fb3d232e38b37db8c6b260f641022fbba48b049d7e/obstore-0.8.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9e1c65c65e20cc990414a8a9af88209b1bbc0dd9521b5f6b0293c60e19439bb7", size = 3947445, upload-time = "2025-09-16T15:34:17.423Z" },
+]
+
+[[package]]
 name = "ollama"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3546,6 +3925,22 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-aiohttp-client"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/d0/b6da40353bcf773f0611a5c79fefedb62cc6cc26d1a83590ec5de45cc7bc/opentelemetry_instrumentation_aiohttp_client-0.62b0.tar.gz", hash = "sha256:c614ca05a2ef513356284db50f442d52fd8b79dbe83b43f630848353f3aff21a", size = 19314, upload-time = "2026-04-09T14:40:24.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a6/f9b4c3dbc6558fbab42b93f1f6f9c0c73ae92a38da2b0c34e09b65eb73d1/opentelemetry_instrumentation_aiohttp_client-0.62b0-py3-none-any.whl", hash = "sha256:7f30e9252870c3264b1c00f7c567c8d34b5ff28808423eca8fdbb87c4e528b6b", size = 14533, upload-time = "2026-04-09T14:39:23.302Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-threading"
 version = "0.62b0"
 source = { registry = "https://pypi.org/simple" }
@@ -3605,6 +4000,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/e6/40b59eda51ac47009fb47afcdf37c6938594a0bd7f3b9fadcbc6058248e3/opentelemetry_semantic_conventions_ai-0.4.13.tar.gz", hash = "sha256:94efa9fb4ffac18c45f54a3a338ffeb7eedb7e1bb4d147786e77202e159f0036", size = 5368, upload-time = "2025-08-22T10:14:17.387Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/b5/cf25da2218910f0d6cdf7f876a06bed118c4969eacaf60a887cbaef44f44/opentelemetry_semantic_conventions_ai-0.4.13-py3-none-any.whl", hash = "sha256:883a30a6bb5deaec0d646912b5f9f6dcbb9f6f72557b73d0f2560bf25d13e2d5", size = 6080, upload-time = "2025-08-22T10:14:16.477Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/e7/830f7c57135158eb8a8efd3f94ab191a89e3b8a49bed314a35ee501da3f2/opentelemetry_util_http-0.62b0.tar.gz", hash = "sha256:a62e4b19b8a432c0de657f167dee3455516136bb9c6ed463ca8063019970d835", size = 11393, upload-time = "2026-04-09T14:40:59.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/7f/5c1b7d4385852b9e5eacd4e7f9d8b565d3d351d17463b24916ad098adf1a/opentelemetry_util_http-0.62b0-py3-none-any.whl", hash = "sha256:c20462808d8cc95b69b0dc4a3e02a9d36beb663347e96c931f51ffd78bd318ad", size = 9294, upload-time = "2026-04-09T14:40:19.014Z" },
 ]
 
 [[package]]
@@ -3762,6 +4166,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3852,15 +4265,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pip"
-version = "26.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3901,6 +4305,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ed/d3/c6c64067759e87af98cc668c1cc75171347d0f1577fab7ca3749134e3cd4/portalocker-2.10.1.tar.gz", hash = "sha256:ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f", size = 40891, upload-time = "2024-07-13T23:15:34.86Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/fb/a70a4214956182e0d7a9099ab17d50bfcba1056188e9b14f35b9e2b62a0d/portalocker-2.10.1-py3-none-any.whl", hash = "sha256:53a5984ebc86a025552264b459b46a2086e269b21823cb572f8f28ee759e45bf", size = 18423, upload-time = "2024-07-13T23:15:32.602Z" },
+]
+
+[[package]]
+name = "postgrest"
+version = "2.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/98/f216b8b5c4d116ab6a2fb21339b5821da279ee773e163612418e1c56c012/postgrest-2.29.0.tar.gz", hash = "sha256:a87081858f627fcd57e8e7137004a1ef0adbdf0dbdfed1384e9ea1d7a9c525ec", size = 14217, upload-time = "2026-04-24T13:13:00.281Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/0b/08b670a93a90d625c557b9e64b8a5fdeec80c3542d2d0265f0b4d6b16646/postgrest-2.29.0-py3-none-any.whl", hash = "sha256:3ee48e146f726272733d20e2b12de354cdb6cb9dd9cc3a61ed97ce69047aeb96", size = 22735, upload-time = "2026-04-24T13:12:58.405Z" },
 ]
 
 [[package]]
@@ -4306,6 +4725,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyiceberg"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "fsspec" },
+    { name = "mmh3" },
+    { name = "pydantic" },
+    { name = "pyparsing" },
+    { name = "pyroaring" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "strictyaml" },
+    { name = "tenacity" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f0/7616676603fdbd05ab97816337a9b31be08a5f9e1ffd636260812b217e0f/pyiceberg-0.11.1.tar.gz", hash = "sha256:366fe0d5a74e3cf1d4e7cbf3c49e308da60e7835ea268667be9185388f05d7a5", size = 1076075, upload-time = "2026-03-03T00:10:27.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/84/a140466b7e0841207e6b77042e03d4ab3a4f9d47e00f0bbbcc5420792bbb/pyiceberg-0.11.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd423b8ee2f75fc9db09158875abe5e2c952a26ae5e521c3265ab2f9d3511ddf", size = 532981, upload-time = "2026-03-03T00:10:08.906Z" },
+    { url = "https://files.pythonhosted.org/packages/17/10/6bedd784010f707680ffd0606d4d11394cf915f4f9f54ae16e8007e00ad4/pyiceberg-0.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e273242cdca56029af694d7ce18075d47a74d034326d663ff6dd2655a6f44825", size = 533188, upload-time = "2026-03-03T00:10:10.086Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a3/79db617c3cffc963efa8a332707079d3f22fd58067b31a208d358dd89b39/pyiceberg-0.11.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b347d3cc8510f8fbe191956fcda7da372ebb3302789acefca08e352345959003", size = 729546, upload-time = "2026-03-03T00:10:11.413Z" },
+    { url = "https://files.pythonhosted.org/packages/06/64/acc11d230c33817bced80d9d947bb49e7bb3a429d76d906523e3df86faf8/pyiceberg-0.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bba3a35b4648694783aeae5b77c235a57191c8b1b375c8602b03ae56a6cf4fe7", size = 730263, upload-time = "2026-03-03T00:10:13.283Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/1a/fb067d5150c7309fbf5dd126c648a6afed6259e7bc924ba3c65d0f87a333/pyiceberg-0.11.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0f958cbca18d05846e3081dfff8575e73d45595441d659847479656dc76f91d", size = 724064, upload-time = "2026-03-03T00:10:14.55Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/71/103fdba5b144d55f3bb07347893737cc1d8fd71308108a77b7817c92c544/pyiceberg-0.11.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8c62636a1e9d8a1fc74ffb70383939b9cd93f2c9ee8e12015a50dd75c98a989e", size = 727239, upload-time = "2026-03-03T00:10:16.204Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c3/4db64429304c58c039f8e842cd37a9a1c472f596c2868ed2a5d2907b17ed/pyiceberg-0.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d6b6f0c1e7dd8357f1ba56524bfc870d04ad3c00979db291784a7145497ad3b", size = 531309, upload-time = "2026-03-03T00:10:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4c/a122d80d98cb6125d87024681263406433f0c25c699d503f5633521e6809/pyiceberg-0.11.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b7ec5db19feab98a31fcd5caccf4a9a4e83f96933d1ca393ba7aea665710c2bb", size = 532644, upload-time = "2026-03-03T00:10:18.574Z" },
+    { url = "https://files.pythonhosted.org/packages/10/94/9a8fa5fc580e6dccd34bbbf51e7658cd7b49540e2458783addeff5e22a91/pyiceberg-0.11.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cec0616d2ba6e7dda6327089a2f34ec723aa9ac2c389857ef0b83f65fb135dd6", size = 532787, upload-time = "2026-03-03T00:10:19.656Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ab/ab7c88828bc17d77dbbc5a765419dfec2135629e1d74cdd0762cd38ad867/pyiceberg-0.11.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ddb360da76c62c7c23ec3da40e1af48e6712a563905fea2d1a8911ff7a3b6c4d", size = 722202, upload-time = "2026-03-03T00:10:21.012Z" },
+    { url = "https://files.pythonhosted.org/packages/df/38/079cf1c0bf86da315472a926eec0dba10135f43374a2e267336eb98d8c76/pyiceberg-0.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d8790f420ebc484236017edba59182cf2a21bd3e4224a0bd0760a9c7268e96a", size = 724037, upload-time = "2026-03-03T00:10:22.176Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6b/08eaef477debb110438d943ef3f5985096f660ccb735d6344701cbd075a9/pyiceberg-0.11.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ae27ba4d37925d5b2cff192acaa70c8bb114d632bbc527cc91fea0370702b866", size = 716035, upload-time = "2026-03-03T00:10:23.789Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/59/7671d6a630ab1d85c6e7ca8ddf438dc63a0b0dd183bc4be69bf25c0fa5f6/pyiceberg-0.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db66a4e0fdfbf4090631d59c3f65e960d9a5561e9259f6f3993cbe91e396837e", size = 720887, upload-time = "2026-03-03T00:10:24.824Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/5c8ad37807efaedb14b20f01f36462684468c80da5b74f4018fb4c1804b5/pyiceberg-0.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:eb3a0a3e630ee89758eb96b39b456f4697732351fb0c080e9498ea578f9b71f9", size = 530923, upload-time = "2026-03-03T00:10:26.196Z" },
 ]
 
 [[package]]
@@ -7051,6 +7506,62 @@ wheels = [
 ]
 
 [[package]]
+name = "pyroaring"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/46/a50510d080f8cb089303ec0f7cd80736b2949ca3d148f48f1cc90c49e345/pyroaring-1.1.0.tar.gz", hash = "sha256:f02e4021397ae02a139defdc6813b9942ab163de90affddd4ce4efbac299f619", size = 200298, upload-time = "2026-04-24T21:29:25.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/e9/d8dcccfdac1657e6a53b6ade0c0c71d59244316810c82537a5d634f8b7fd/pyroaring-1.1.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:fdf484d26016e0c016f23f2b635d2899daec034565fdcc062ed6b10f3b26a3f4", size = 334166, upload-time = "2026-04-24T21:28:07.184Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/16/70f8268c9bac4f6d91a82df254332edfa07020fe02e97c6d3d0295ee4db3/pyroaring-1.1.0-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:e9c2b9aa8decdcf40ed8f4c887092c20a272f8c32215c3fee65e9db92ecf418e", size = 711970, upload-time = "2026-04-24T21:28:08.929Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a6/0b88a8a8e4ffdd0bf53765c3ea17ce3b747f7de42b1f10d5c50a13ba3ecc/pyroaring-1.1.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:5eb031237e9d39cbdfc9276facacdd88e27aefb58940bd8b56b878dfd38d6022", size = 385825, upload-time = "2026-04-24T21:28:10.077Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a7/f06a899b896bb74a031201fbba707abf23e2485f44ead28d2e91977ee204/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66aa6a321fbc598f26d5e66050a7f145c2253f3fe5737b589841ff0cbe5cb177", size = 2000799, upload-time = "2026-04-24T21:28:11.276Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/16/b13e0727ef5c91c84ac5d9b5c4af43cb3f28d8822d96d44aa4aeefc10b37/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8cff06d18c9a30f8547a92757078aa345db1ba5b22e3082a05f64e50b384e27a", size = 1843405, upload-time = "2026-04-24T21:28:12.394Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4b/ff77d6eb4747c65aba49d345318059f1ccfbd206bbcd34686cea819187e9/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:043dbbaa905f7288c515ac06a96b67a3763f35e9ae06f0c0278c0d9964d16760", size = 2224307, upload-time = "2026-04-24T21:28:13.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d1/9b4e2175a9bd07592ef1c6f4692ba0cfe3abd54f33ebd574aa2b2ab88c2c/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:71fec09bd42f8c33ac3b762cd00c5db842eb583ffd0e361739ce1c17ad078a6a", size = 2902586, upload-time = "2026-04-24T21:28:15.485Z" },
+    { url = "https://files.pythonhosted.org/packages/67/24/904952d6bfe2e4946f361958157774230cb1ac171d306e2460620274c58a/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c9f30ca28b991a920b446ed3ee19c7ecafcc49c46db592abf89cf239a7bb45f4", size = 2741581, upload-time = "2026-04-24T21:28:17.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f5/8ad5605870fbdcb568f0b847e1fea24adea15e07c90231fb62f339c08b14/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:67650460c65bdd7b4f5078d9c955aa38f64627d02cb48f9cfb24eae84bca2aba", size = 3182906, upload-time = "2026-04-24T21:28:18.435Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5d/264414a1b1bea72b2a7756e2b1dca709e5c695b0cd332a8f90c297ae3b33/pyroaring-1.1.0-cp312-cp312-win32.whl", hash = "sha256:61a8eabee99104ca197b6e7cce05dc4f27f503be52881800cd370eb5a5152d3f", size = 211231, upload-time = "2026-04-24T21:28:20.414Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/39/dd3341e235a3794c613ea32bd35618a88ff2ae067dbe9dd7c382c8c146d2/pyroaring-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:51ebe5e6f48e3dc9df91a4cb62137ef72e1469acd6f37479abd9991f6d945cc9", size = 263337, upload-time = "2026-04-24T21:28:21.371Z" },
+    { url = "https://files.pythonhosted.org/packages/12/5d/bb8e93dd7412180c621086ed46014a0f09f9a71d9370ce8cf607c5a2cf00/pyroaring-1.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:9882a204178cc8c915e0ce30abb4bdd1668e383c571b06649d5ed272d9625877", size = 216727, upload-time = "2026-04-24T21:28:22.536Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/75/1d39ecb04e6cd96d191eb8884864355051df80928dd5096a9dea43fbf63b/pyroaring-1.1.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:72f68a16b00b35481d9b3bfe897ecd8a1f7da69efd92ba5b17347ca11c21cb0d", size = 333363, upload-time = "2026-04-24T21:28:23.838Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3e/65cd0871e86d11c5c5cfd0f5abb0ca80eb2b6b5dbe5a2433f315a9ebd90c/pyroaring-1.1.0-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:4c443e9f942b6089efe8c9b264576e9d116f90be28a315679375bba2d8a915d6", size = 710573, upload-time = "2026-04-24T21:28:24.884Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a2/f8f23515f41414332e60cd86e4957e2a6838070b2ad5fe25e80f136de635/pyroaring-1.1.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:3beb40eb1220d1ce4fb3661bb019e9a21857e5bb294fe8c1c5016aeb6e82318c", size = 384880, upload-time = "2026-04-24T21:28:25.864Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5b/82dc44b5074a1ff62e702d12611272d1711a60d5518dab23f94e1f7a9b3d/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f1f56004e8f1c1489bf279c25f1fa4764252cd9af5fb35675774268a4a615ba", size = 1999529, upload-time = "2026-04-24T21:28:26.859Z" },
+    { url = "https://files.pythonhosted.org/packages/11/40/b07bac8cdc4b709a05f5c55bb52d4f684e5ea1fadfa0b6d9decf477a9d2a/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:13660386ea8905ee4d42c21a6275463e2dc7d31e0b5d65eec210aa7043ad96f4", size = 1842927, upload-time = "2026-04-24T21:28:28.056Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/60/c4b511965802dfc77978a9e16f2813f47fb3083db1822019ba1bb169c685/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0dfb6cf50fd8898179e460e699a6b8326ca508c627d083f7bf62f769fe1717d5", size = 2199538, upload-time = "2026-04-24T21:28:29.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/12/38f6b50b3f3f41a8b752d3e9efcf105b18eb2c66811831059f25613734ac/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:81ebbc0c880c8a10f13118632e5c0d59159ceada8b651bba18f2e6dc70efdeda", size = 2896904, upload-time = "2026-04-24T21:28:30.67Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b6/b5436e4b93c6bf2bd3dd6ccb88cbdc64b12084151a43e2f5c94be50eb710/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:370d191b0d1b32bbd99452ef5f0485f22fcc4bf7404d33b821d0ce2459951152", size = 2733819, upload-time = "2026-04-24T21:28:31.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/8f/f392f268de9607a5c7a95aaed6b9c8a81f00c14d85c33855e9f492095478/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8b3bfad0ae3ef0e67b40c193863dce8b7d79de545dadbe53c19acc3ace38f66", size = 3161730, upload-time = "2026-04-24T21:28:33.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a1/03250fd4834b6a5c13e6600bca47ea20fda579f80bce3551d4985185d164/pyroaring-1.1.0-cp313-cp313-win32.whl", hash = "sha256:eead129046822cb0fd47c78740b81bdaffd0515c0bb0306a2318acf0f0540b58", size = 211194, upload-time = "2026-04-24T21:28:35.001Z" },
+    { url = "https://files.pythonhosted.org/packages/70/63/d9b307462cddc82fe94a67d6810e5c802818690e131ba690c1de674d8558/pyroaring-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:90ab2f00c09eed5bd986a80c8641e2dc10e7aca1a2d892d89a44b396e39c08ea", size = 263110, upload-time = "2026-04-24T21:28:35.976Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4a/aa6e9833a6ba9a630efdbec8783b63da6602f763b37a5b5fbc01d73a1af1/pyroaring-1.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:51dd2490a64ad4ed53c4fb58ef1ee3f84f6cbd97cdb47abd9065c9f714ab72ef", size = 216546, upload-time = "2026-04-24T21:28:37.065Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ab/2260fd567a2d5d957393b932ea940dc31146bd509c88164c1b786eee7836/pyroaring-1.1.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:5e337f8c5b3c2e0c27da83fc2cb702684a47eee907a960cfee964fcb5344515b", size = 335093, upload-time = "2026-04-24T21:28:38.325Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/df82a832ff3760c7c7653b80d030fb43b18eb88bfa604e7de3e84457286e/pyroaring-1.1.0-cp314-cp314-macosx_14_0_universal2.whl", hash = "sha256:53acecba8f898e96b84d4139356e30719c70358177e270055901d3ec1cb0e34c", size = 712387, upload-time = "2026-04-24T21:28:39.404Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b9/a94d6b2d7a1be2fa5009ecfc345bacb2ee0b536020aeb23e92c6bb7e70f2/pyroaring-1.1.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:986efb3aec7655d69c14db2309a2072dbf181bdb906091fede83ad18e316cdaf", size = 385413, upload-time = "2026-04-24T21:28:40.563Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6a/3658eadbe28a5a2093c27857dd21441f1ea1cede2ddbe367df76e3018859/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92643c9dd303de8960c3dbed93a28b8d87da5ed0a7776568979f379d7bc8a885", size = 1995135, upload-time = "2026-04-24T21:28:41.931Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/4706ec770790d3433520eb0ea98fc662ccb1533164fd00b01f3413c3425c/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6a1d4c59d5b23c01d62f86d57ceefd0c0977de0425aafa7069f2d70563fed3b8", size = 1833652, upload-time = "2026-04-24T21:28:43.381Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/38/b8b861738e49fd4c4a54bebe257dced603999365629b4e10cb85fac940b0/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8ac1bc26223befbca986551521f37f4c1670dfe26fccb2f0fc2775e75be99c1", size = 2188218, upload-time = "2026-04-24T21:28:44.487Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8c/96afa9b5f509a5c607deaf30538edb3bdf026447a864cfe3f2c3d7484875/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b490f2d22df30affbfdcbe4f7896f321edb72a8dc0cbe5f38adec3de5b947c25", size = 2898243, upload-time = "2026-04-24T21:28:45.9Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/86f8720525250fe742fc77ea5c2a2074a1ea830efe84a79112ce6fe113d3/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:56a67794188275f8897a8f1fa64d6313c48241bebbdef38833063e7281b29ef8", size = 2715091, upload-time = "2026-04-24T21:28:47.721Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/21/29e8f58c8af2ce016904a7e6aa61be675945224971cd70f3f698e584a23f/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9d9f196007f0b15ea19c21732faacaea83cbf5946b6db4949b3b98cf871c93f0", size = 3149470, upload-time = "2026-04-24T21:28:48.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/e1/f67ef1c9de461a80707a2f2981320b1b30632720bac426a9bfd51e4744b6/pyroaring-1.1.0-cp314-cp314-win32.whl", hash = "sha256:abc0f0ce22464864fea208315d25e999e45cb5ee646ac1ca11d314a6a51dbe4a", size = 216552, upload-time = "2026-04-24T21:28:50.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/83/a8d9fee17e6eedf2a2281b2aabcdde86930408486381ec48d1f7d3404521/pyroaring-1.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:532ae6bb1d3431d9956ef07589dd5c8dd918301a83d937c7dc6e511b1364d76a", size = 270712, upload-time = "2026-04-24T21:28:51.817Z" },
+    { url = "https://files.pythonhosted.org/packages/42/50/ab2bf3fe45e4c2952690d657321a8470558f92cf93cb197fe5d31f7110d2/pyroaring-1.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:d2706a89242a347be20805147d58a38f4f4d8f6846228c4ee8dfd3587113719c", size = 224783, upload-time = "2026-04-24T21:28:53.183Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0c/9eb48ac698280170f184045814b7bd44829af37c1c6de79a4d7b5ea0c8b8/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:39eff7dd06c163c22d0a9f9fd72d27e671457bea8cdb71215382a10512539e1d", size = 345689, upload-time = "2026-04-24T21:28:54.494Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/61/66b18f8ed17e70f88a410dcfac21e5964c2ad01bd4d6a25024a87522c8a9/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_universal2.whl", hash = "sha256:562fa04bbfd41144d1276ed79505007557c161371450d68a1d71fc83dc01d083", size = 732373, upload-time = "2026-04-24T21:28:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/04/7a/976482874ea5e4476f9dd84e7d0274e480446b1b6ab45dfe301281814b3b/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:591e2ed4d60443dafd9075c1f72e9aaf359ccf5120e32a8c340c2b2ae3da45e7", size = 392985, upload-time = "2026-04-24T21:28:56.629Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/22/1eed09ff3aa792865dd52ef447cbe52dbc5901ed88bf1cf4513f7220150e/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:381eda673442c389993f8b0db2dbf5d02ea8ea9aac6ba736f64cc1ffb6c96885", size = 2045479, upload-time = "2026-04-24T21:28:58.008Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/de43464f9b28c445868e4bc8f0e6c6dcd51103bd9a757e3dcd9af25a4a69/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d9127feb5356ba3a92bdffa04c1bf6bcbc8d436369f78badf441018c3029dd63", size = 1853013, upload-time = "2026-04-24T21:28:59.265Z" },
+    { url = "https://files.pythonhosted.org/packages/03/17/29b128a580ec43905fb766b934e7dcb1095059e99e38e941edf50152207b/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:650db21c10f42ff2b09ef02c10a779a3d59d0c7512552f3844738b30adbcb8a5", size = 2222628, upload-time = "2026-04-24T21:29:00.792Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d8/bb7d69978a5fcac95da48bedb114554d8345b50b77f042e8cd2a8277bb4b/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a5fbcb86e44f1c0c9c052917eee67a04cbac9de7392fb4bc77c140ff4a7e471", size = 2931231, upload-time = "2026-04-24T21:29:02.275Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/12/d44d144352a4586544313a97b2576f8f8673b98c02ae7fed77d38751cc1f/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0f1d76ef29034017eb2cceebd5fa0504d6ced218ce6432f99da5adecbe038269", size = 2729546, upload-time = "2026-04-24T21:29:03.414Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f9/0d01c6ba01c0d01609fddb1d46138a7ae95b7db386bac4afb0ff082d5c0e/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:19d0c81c865d63791fe20e5b38733b66f4f962e677ae7e8b3d3c4947ac6e752f", size = 3177123, upload-time = "2026-04-24T21:29:04.619Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6d/f991526fdef3cf7739f6db0cdf12b157e840e0ddd4a7e1c2a477da9072d6/pyroaring-1.1.0-cp314-cp314t-win32.whl", hash = "sha256:1fc112b9a9890f89cc645a16604783ed7fa25299f149b0ef7b45a5e2e3c1f31f", size = 241484, upload-time = "2026-04-24T21:29:06.114Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/6e/fb9876940acb50df355a473c087b9924e7b3368070403683941653b6fabc/pyroaring-1.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d92a0f4c7e6bb7deeafac68c79c92ef9340895fe825cf1a31078443753ab6756", size = 304537, upload-time = "2026-04-24T21:29:07.312Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e0/39afe4bddbed6276c54e35e310aa345fbeb00f8890e96e7f48cdc2be9c66/pyroaring-1.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:99c42fe1449acfbf130da65e66b4d5b2726aba4497be359bae7672e38a15fc62", size = 234615, upload-time = "2026-04-24T21:29:08.751Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -7295,6 +7806,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+]
+
+[[package]]
+name = "realtime"
+version = "2.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/f1/08c42a42653942fadfbef495d5b0239356140e7186cc528704956c5f06d4/realtime-2.29.0.tar.gz", hash = "sha256:8efe4a1b3a548a5fda09de701bd041fa0970c5a2fe7d13db0b9861ce11828be2", size = 18715, upload-time = "2026-04-24T13:13:02.315Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/48/f6375c0a24923beb988f0c71c052604c96641cf43c2d22b91ec1df86afa0/realtime-2.29.0-py3-none-any.whl", hash = "sha256:1a4891e6c82e88ac9d96ac715e435e086f6f8c7665212a8717346de829cbb509", size = 22374, upload-time = "2026-04-24T13:13:01.103Z" },
 ]
 
 [[package]]
@@ -7580,6 +8105,44 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "scantree"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pathspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/e4/40998faefc72ba1ddeb640a44fba92935353525dba110488806da8339c0b/scantree-0.0.4.tar.gz", hash = "sha256:15bd5cb24483b04db2c70653604e8ea3522e98087db7e38ab8482f053984c0ac", size = 24643, upload-time = "2024-08-03T20:08:59.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/ce/828467ddfa0d2fe473673026442d2032d552a168e42cfbf25fd0e5264e0c/scantree-0.0.4-py3-none-any.whl", hash = "sha256:7616ab65aa6b7f16fcf8e6fa1d9afaa99a27ab72bba05c61b691853b96763174", size = 20690, upload-time = "2024-08-03T20:08:58.137Z" },
+]
+
+[[package]]
 name = "screeninfo"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7644,6 +8207,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "shortuuid"
+version = "1.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/e2/bcf761f3bff95856203f9559baf3741c416071dd200c0fc19fad7f078f86/shortuuid-1.0.13.tar.gz", hash = "sha256:3bb9cf07f606260584b1df46399c0b87dd84773e7b25912b7e391e30797c5e72", size = 9662, upload-time = "2024-03-11T20:11:06.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/44/21d6bf170bf40b41396480d8d49ad640bca3f2b02139cd52aa1e272830a5/shortuuid-1.0.13-py3-none-any.whl", hash = "sha256:a482a497300b49b4953e15108a7913244e1bb0d41f9d332f5e9925dba33a3c5a", size = 10529, upload-time = "2024-03-11T20:11:04.807Z" },
 ]
 
 [[package]]
@@ -7764,6 +8336,89 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "storage3"
+version = "2.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "pyiceberg" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/be/771246434b5caf3c6187bfdc932eaede00bf5f2937b47475ab25209ede3e/storage3-2.29.0.tar.gz", hash = "sha256:b0cc2f6714655d725c998d2c5ae8c6fb4f56a513bd31e4f85770df557fe021e3", size = 20160, upload-time = "2026-04-24T13:13:04.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/c3/790c31866f52c13b26f108b45759bf50dafae3a0bafb4511fadc98ba7c33/storage3-2.29.0-py3-none-any.whl", hash = "sha256:043ef7ff27cc8b9da12be403cf78ee4586180edfcf62b227ff61e1bd79594b06", size = 28284, upload-time = "2026-04-24T13:13:03.338Z" },
+]
+
+[[package]]
+name = "strenum"
+version = "0.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ad/430fb60d90e1d112a62ff57bdd1f286ec73a2a0331272febfddd21f330e1/StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff", size = 23384, upload-time = "2023-06-29T22:02:58.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659", size = 8851, upload-time = "2023-06-29T22:02:56.947Z" },
+]
+
+[[package]]
+name = "strictyaml"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206, upload-time = "2023-03-10T12:50:27.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917, upload-time = "2023-03-10T12:50:17.242Z" },
+]
+
+[[package]]
+name = "supabase"
+version = "2.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "postgrest" },
+    { name = "realtime" },
+    { name = "storage3" },
+    { name = "supabase-auth" },
+    { name = "supabase-functions" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/a0/2407d616fdf68e8632bbbfb063d1685c38377ac0199e8ca11deaea1f3bf0/supabase-2.29.0.tar.gz", hash = "sha256:a88c4a4eb50fbb903e2e962fbc7c27733b00589140139f9e837bc9fe30dd3615", size = 9689, upload-time = "2026-04-24T13:13:06.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/52/232f6bbf5326e04ae12e2ef04a24f011a0d7cab379a8b9698652bc8ff78f/supabase-2.29.0-py3-none-any.whl", hash = "sha256:16c3ec4b7094f6b92efc5cd3bb3f96826d3b6dd5d24fe15c89c81166efce88fe", size = 16633, upload-time = "2026-04-24T13:13:05.722Z" },
+]
+
+[[package]]
+name = "supabase-auth"
+version = "2.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/7f/7ceeb4c7a2caa188062e934897f0e08e1af0a0e47e376c7645c26b4c39d8/supabase_auth-2.29.0.tar.gz", hash = "sha256:46efc6a3455a23957b846dc974303a844ba0413718cfa899425477ac977f95b3", size = 39154, upload-time = "2026-04-24T13:13:08.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/ac/3c35cf52281f940b9497cf17abfc5c2050ca49f342d60cfafe22dac3482b/supabase_auth-2.29.0-py3-none-any.whl", hash = "sha256:64de6ef8cae80f97d3aa8d5ca507d5427dda5c89885c0bcfe9f8b0263b6fb9a4", size = 48379, upload-time = "2026-04-24T13:13:07.417Z" },
+]
+
+[[package]]
+name = "supabase-functions"
+version = "2.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "strenum" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/19/1a1d22749f38f2a6cbca93a6f5a35c9f816c2c3c06bfaa077fa336e90537/supabase_functions-2.29.0.tar.gz", hash = "sha256:0f8a14a2ea9f12b1c208f61dc6f55e2f4b1121f81bf01c08f9b487d22888744d", size = 4683, upload-time = "2026-04-24T13:13:10.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/10/6f8ef0b408ade76b5a439afab588ce5849e9604a23040ca73cfe0b90cb9e/supabase_functions-2.29.0-py3-none-any.whl", hash = "sha256:6f08de52eec5820eae53616868b85e849e181beffaa5d05b8ea1708ceae5e48e", size = 8799, upload-time = "2026-04-24T13:13:09.214Z" },
 ]
 
 [[package]]
@@ -7904,6 +8559,15 @@ wheels = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
 name = "tomli-w"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -8014,6 +8678,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/92/e97fcc6b2c27cdb87ce5ee063d77f8f26f19f06916aa680464c8104ef0f6/triton-3.5.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0b4d2c70127fca6a23e247f9348b8adde979d2e7a20391bfbabaac6aebc7e6a8", size = 170579924, upload-time = "2025-11-11T17:41:12.455Z" },
     { url = "https://files.pythonhosted.org/packages/a4/e6/c595c35e5c50c4bc56a7bac96493dad321e9e29b953b526bbbe20f9911d0/triton-3.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0637b1efb1db599a8e9dc960d53ab6e4637db7d4ab6630a0974705d77b14b60", size = 170480488, upload-time = "2025-11-11T17:41:18.222Z" },
     { url = "https://files.pythonhosted.org/packages/16/b5/b0d3d8b901b6a04ca38df5e24c27e53afb15b93624d7fd7d658c7cd9352a/triton-3.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bac7f7d959ad0f48c0e97d6643a1cc0fd5786fe61cb1f83b537c6b2d54776478", size = 170582192, upload-time = "2025-11-11T17:41:23.963Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2026.4.28.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/88fdebf242bc7bc4957c96c5358a2b2b0f07e5001401906783a521ea9f54/trove_classifiers-2026.4.28.13.tar.gz", hash = "sha256:c85bb8a53c3de7330d1699b844ed9fb809a602a09ac15dc79ad6d1a509be0676", size = 17035, upload-time = "2026-04-28T13:45:41.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/bb/fbdc4e57731efb86b4209ffdd2519520782bf27b3c961beac3e5c20d2b87/trove_classifiers-2026.4.28.13-py3-none-any.whl", hash = "sha256:8f4b1eb4e16296b57d612965444f87a83861cc989a0451ac97fe4265ddef03b8", size = 14216, upload-time = "2026-04-28T13:45:39.943Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]
@@ -8225,47 +8913,33 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "16.0"
+version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
-    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
-    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
-    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
-    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
-    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
-    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
-    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
-    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
-    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]
@@ -8525,4 +9199,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
Adds a `HarborAgent` that lets EvoSkill use Harbor sandboxes as the base-agent execution layer. Skills evolved by EvoSkill bind-mount into Harbor task containers via `--mounts-json`; rewards from Harbor's verifier flow back through a JSON envelope.

The integration repackages Harbor's containerized verifier outputs into the (question, answer, score) protocol EvoSkill's loop already uses, so 190+ Harbor benchmarks become drop-in replacements for the manually-labeled CSV, with the in-container verifier replacing string-match scoring.

### Why
Without this, EvoSkill needs a CSV with manually-labeled (question, answer) pairs. With this, you can point EvoSkill at any of 190+ Harbor benchmarks (terminal-bench-pro, swe-bench-pro, ARC-AGI-2, …) and the verifier IS the ground truth.

### Result
On `terminal-bench-pro` (mix of easy + hard, 10 tasks, opencode + 
openrouter/minimax/minimax-m2.7):

| Iter | Accuracy | Δ        | Status                  |
|------|----------|----------|-------------------------|
| 0    | 33.3%    | —        | baseline                |
| 1    | 33.3%    | +0.0%    | tied best               |
| 3    | 66.7%    | **+33.3%** | ★ new best (+1 skill) |

Best skill found: `verifier-interface-alignment` — captures "local tests
passing ≠ verifier passing", the exact failure mode that scuppered the 
build-grpc-user-profile-service task.

Total cost: $0.12 in OpenRouter credits over the run.

### Changes
- New: `src/harness/harbor/agent.py` (HarborAgent — overrides `Agent.run`)
- New: `src/api/harbor_loader.py` (downloads → DataFrame, supports include/exclude/difficulty filters)
- New: `src/evaluation/harbor_scorer.py`
- Config: `dataset.source = "harbor"` + new `[harbor]` section
- 4 file modifications to wire in the new harness

### Known limitations (not blockers, worth flagging)
- `[harbor].env = "daytona"` doesn't inject skills — Harbor's Daytona env
  ignores `mounts_json`. Docker mode works fully; Daytona needs a
  Dockerfile-bake fallback (separate PR).
- `harbor>=0.6.1` is a hard dep in `pyproject.toml`. Could move to
  `[project.optional-dependencies]` if upstream prefers.
- No tests added yet — happy to add if/when this lands as a direction.

### How to try it
```bash
export OPENROUTER_API_KEY=sk-or-...
harbor download terminal-bench-pro/terminal-bench-pro -o ./tbp
# config.toml:
#   [dataset]    source = "harbor", harbor_tasks_root = "./tbp"
#   [scorer]     type = "harbor"
#   [harbor]     enabled = true, inner_agent = "opencode", env = "docker"
evoskill run
```


### Sample
<img width="1948" height="911" alt="image" src="https://github.com/user-attachments/assets/99719f92-9c41-4fa0-ae2a-8be890259e37" />

<br>

### Latest update on harbor integration :

The HarborAgent's failure trace deliberately omits job_dir and the inner agent's session messages, so the EvoSkill proposer has no direct path-pointer into Harbor's verifier output (/tests/, verifier/test-stdout.txt, etc.). Inner-agent isolation is provided by Harbor's design: /tests/ is mounted post-execution and was confirmed unreachable across all agent logs in our test run.
