### PR TITLE
fix(cache): drop wall-clock timestamp from program.yaml metadata

### DIFF
--- a/src/registry/models.py
+++ b/src/registry/models.py
@@ -82,6 +82,12 @@ class ProgramConfig(BaseModel):
         Returns:
             A new ProgramConfig with this program as parent
         """
+        # NOTE: do NOT call .with_timestamp() here. A wall-clock timestamp
+        # on every child program would byte-change program.yaml on each
+        # iteration and bust the run-cache (which keys on the workspace's
+        # git tree SHA). Git's commit timestamp already records iteration
+        # ordering. See src/cache/run_cache.py:_get_tree_hash and the
+        # parallel comment in src/registry/sdk_utils.py.
         return ProgramConfig(
             name=name,
             parent=f"program/{self.name}",
@@ -90,4 +96,4 @@ class ProgramConfig(BaseModel):
             allowed_tools=allowed_tools or self.allowed_tools,
             output_format=output_format if output_format is not None else self.output_format,
             metadata=metadata or {},
-        ).with_timestamp()
+        )

--- a/src/registry/sdk_utils.py
+++ b/src/registry/sdk_utils.py
@@ -117,7 +117,14 @@ def options_to_config(
     Returns:
         ProgramConfig ready for git storage
     """
-    base_metadata = {"created_at": datetime.now().isoformat()}
+    # NOTE: deliberately do NOT include `created_at` here. The timestamp
+    # would byte-change program.yaml on every --fresh launch, which in turn
+    # changes the workspace's git tree SHA and busts the run-cache key (see
+    # src/cache/run_cache.py:_get_tree_hash). Git's commit timestamp already
+    # records when the program was created, so the metadata field is
+    # redundant and only serves to defeat caching across re-runs of the
+    # same content.
+    base_metadata: dict[str, Any] = {}
     if metadata:
         base_metadata.update(metadata)
 


### PR DESCRIPTION
## Summary

Two write paths embed a fresh `created_at` timestamp into every `program.yaml`:
- `src/registry/sdk_utils.py:options_to_config` — for the base program
- `src/registry/models.py:ProgramConfig.child` — for mutated programs

The run-cache (`src/cache/run_cache.py`) keys on the workspace's git tree SHA. Tree SHAs are content-addressed and were chosen specifically so identical content produces the same hash across `--fresh` launches. But the embedded timestamp byte-changes `program.yaml` on every launch / iteration, which busts the cache key and forces full re-inference even when nothing else has changed.

**Net effect on a fresh re-run of the same dataset:** 100% cache miss on base eval (~$5–$15 per re-run depending on dataset size and config).

**Fix:** drop the `created_at` field. Git's commit timestamp already records when each program was created, so the metadata field is redundant and only serves to defeat caching.

## Test plan
- [x] Verified locally: relaunched evolution on the same dataset with `--fresh true` → second run's tree-hash matches the first run's; cache hits would now apply.
- [x] Inspected resulting `program.yaml` — `metadata: { sdk: claude }` (timestamp removed; `sdk` field preserved).
- [ ] Reviewer to confirm no downstream consumer reads `metadata.created_at` (`grep -r "metadata.*created_at"` on the codebase returns no usages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)