### PR TITLE
fix: pass encoding='utf-8' to Path.write_text on all text outputs

### DIFF
--- a/src/cli/commands/init.py
+++ b/src/cli/commands/init.py
@@ -352,7 +352,7 @@ def init_cmd():
             'remote': remote_config,
         },
     )
-    (evoskill_dir / 'task.md').write_text(TASK_MD_TEMPLATE)
+    (evoskill_dir / 'task.md').write_text(TASK_MD_TEMPLATE, encoding='utf-8')
 
     # Save init-time state (original branch for reset landing)
     original_branch = 'main'
@@ -365,7 +365,7 @@ def init_cmd():
     except (subprocess.CalledProcessError, FileNotFoundError):
         pass
     state = {'original_branch': original_branch}
-    (evoskill_dir / 'state.json').write_text(json.dumps(state, indent=2) + '\n')
+    (evoskill_dir / 'state.json').write_text(json.dumps(state, indent=2) + '\n', encoding='utf-8')
 
     click.echo(f'\n  ✓ Created {cwd}/{EVOSKILL_DIR}')
     click.echo(f'    Runtime:   {harness}')

--- a/src/cli/report.py
+++ b/src/cli/report.py
@@ -59,7 +59,7 @@ class RunReport:
         reports_dir.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.now().strftime('%Y-%m-%d-%H%M%S')
         path = reports_dir / f'run-{timestamp}.md'
-        path.write_text(self._render_markdown())
+        path.write_text(self._render_markdown(), encoding='utf-8')
         return path
 
     def _render_markdown(self) -> str:

--- a/src/harness/opencode/options.py
+++ b/src/harness/opencode/options.py
@@ -104,7 +104,7 @@ def ensure_opencode_project_permissions(
 
     permission["external_directory"] = external_directory
     config["permission"] = permission
-    config_path.write_text(json.dumps(config, indent=2) + "\n")
+    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding='utf-8')
 
 
 def build_opencode_options(

--- a/src/harness/opencode/skill_utils.py
+++ b/src/harness/opencode/skill_utils.py
@@ -73,7 +73,7 @@ def ensure_skill_frontmatter(
         return False
 
     frontmatter = yaml.safe_dump(metadata, sort_keys=False).strip()
-    skill_path.write_text(f"---\n{frontmatter}\n---\n\n{body.lstrip()}")
+    skill_path.write_text(f"---\n{frontmatter}\n---\n\n{body.lstrip()}", encoding='utf-8')
     return True
 
 

--- a/src/loop/helpers.py
+++ b/src/loop/helpers.py
@@ -224,7 +224,7 @@ def update_prompt_file(file_path: Path, new_prompt: str) -> None:
         file_path: Path to the prompt file.
         new_prompt: The new prompt content.
     """
-    file_path.write_text(new_prompt.strip())
+    file_path.write_text(new_prompt.strip(), encoding='utf-8')
 
 
 def build_skill_query_from_skill_proposer(

--- a/src/loop/runner.py
+++ b/src/loop/runner.py
@@ -193,7 +193,7 @@ class SelfImprovingLoop:
             "per_cat_offset": self._per_cat_offset,
         }
         self._checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
-        self._checkpoint_path.write_text(json.dumps(checkpoint, indent=2))
+        self._checkpoint_path.write_text(json.dumps(checkpoint, indent=2), encoding='utf-8')
 
     def _load_checkpoint(self) -> int | None:
         """Load checkpoint if exists.


### PR DESCRIPTION
## Summary

`Path.write_text()` falls back to `locale.getpreferredencoding(False)` when the `encoding` argument is omitted. On Windows machines running a non-UTF-8 system locale (Hebrew/cp1255, Cyrillic/cp1251, Japanese/cp932, etc.), writing strings that contain characters outside the ANSI codepage raises `UnicodeEncodeError`.

This PR pins `encoding='utf-8'` on every `write_text()` call site that emits text content.

## Reproduction (Windows + Hebrew locale)

```powershell
pipx install evoskill
cd <empty-dir>
evoskill init
```

Crash:
```
File "...\src\cli\commands\init.py", line 355, in init_cmd
    (evoskill_dir / 'task.md').write_text(TASK_MD_TEMPLATE)
  ...
  File "C:\Python314\Lib\encodings\cp1255.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '→' in position 141: character maps to <undefined>
```

`TASK_MD_TEMPLATE` contains `→` (U+2192), which is not representable in cp1255.

## Files changed

| File | Content written | Risk if not UTF-8 |
|---|---|---|
| `src/cli/commands/init.py:355` | `task.md` (TASK_MD_TEMPLATE — contains `→`) | **Crashes `evoskill init` immediately** |
| `src/cli/commands/init.py:368` | `state.json` | Defensive — JSON values may include non-ASCII branch names |
| `src/cli/report.py:62` | `run-<timestamp>.md` (run report) | Reports often contain emoji/arrows from agent traces |
| `src/harness/opencode/options.py:107` | OpenCode JSON config | Defensive — paths/instructions may include non-ASCII |
| `src/harness/opencode/skill_utils.py:76` | Evolved `SKILL.md` (frontmatter + body) | **Will crash on any evolved skill containing arrows, em-dashes, smart quotes** |
| `src/loop/helpers.py:227` | Evolved prompt files | **Will crash on any prompt the proposer generates with non-ASCII** |
| `src/loop/runner.py:196` | `loop_checkpoint.json` | Defensive — checkpoint values are numeric but should be UTF-8 explicit |

Each change is `write_text(x)` → `write_text(x, encoding='utf-8')`. No behavior change on UTF-8-default systems (most Linux/macOS); fixes the crash on Windows non-UTF-8 locales.

## Why this matters beyond the immediate crash

Even if a user gets past `evoskill init` (e.g., on a US-English Windows install), the SKILL.md and prompt files are written by **the LLM-driven proposer**. The proposer routinely emits Unicode (em-dashes, arrows, curly quotes) when it rewrites a skill. So `evoskill run` is also affected on any non-UTF-8 locale, just on a less predictable iteration. Pinning UTF-8 once removes the entire class of bugs.

## Out of scope

Two more `write_text()` call sites exist that were not patched here because I didn't exercise their code paths during reproduction:

- `src/docker/launcher.py:111` (compose file)
- `src/remote/base.py:28` (remote run record)

The same change is recommended in a follow-up.

## Test plan

- [x] Manual: `evoskill init` succeeds on Windows 11 + Hebrew locale (cp1255) + Python 3.14
- [x] Manual: `evoskill run` writes `SKILL.md` with em-dashes and arrows without error
- [ ] No new tests added — change is a one-character explicit-encoding hint per call site, behavior identical on UTF-8-default systems