### PR TITLE
fix: use async session API for heavy upload commands

### DIFF
--- a/src/remote/daytona.py
+++ b/src/remote/daytona.py
@@ -21,6 +21,38 @@ from src.remote.sync import (
 )
 
 SESSION_ID = "evoskill-run"
+UPLOAD_SESSION_ID = "evoskill-upload"
+
+
+def _exec_async(sandbox, session_id: str, command: str, *,
+                poll_interval: float = 3.0, max_wait_seconds: int = 1800) -> None:
+    """Run a long-running command on the sandbox without blocking on HTTP.
+
+    Uses Daytona's session API with run_async=True so the SDK call returns
+    immediately. Polls get_session_command() until exit_code is set. This
+    avoids ConnectionResetError that occurs when a single exec() call blocks
+    long enough for the server/proxy to drop the connection.
+    """
+    from daytona import SessionExecuteRequest
+
+    req = SessionExecuteRequest(command=command, run_async=True)
+    response = sandbox.process.execute_session_command(session_id, req)
+    cmd_id = response.cmd_id
+
+    deadline = time.monotonic() + max_wait_seconds
+    while time.monotonic() < deadline:
+        info = sandbox.process.get_session_command(session_id, cmd_id)
+        if info.exit_code is not None:
+            if info.exit_code != 0:
+                logs = sandbox.process.get_session_command_logs(session_id, cmd_id)
+                tail = (logs.output or logs.stdout or logs.stderr or "")[-4000:]
+                raise RuntimeError(
+                    f"Sandbox command failed (exit={info.exit_code}):\n{command}\n--- logs ---\n{tail}"
+                )
+            return
+        time.sleep(poll_interval)
+
+    raise RuntimeError(f"Sandbox command timed out after {max_wait_seconds}s:\n{command}")
 
 
 def _make_client(api_key: str):
@@ -120,6 +152,11 @@ class DaytonaBackend(RemoteBackend):
         if log is None:
             log = lambda msg: None  # noqa: E731
 
+        # Create a session for long-running upload-side commands. Heavy work
+        # is dispatched via _exec_async (run_async + polling) so the SDK never
+        # holds a single HTTP connection long enough for the server to drop it.
+        sandbox.process.create_session(UPLOAD_SESSION_ID)
+
         # 1. Create and upload git bundle
         log("git bundle...")
         with tempfile.NamedTemporaryFile(suffix=".bundle", delete=False) as f:
@@ -130,9 +167,10 @@ class DaytonaBackend(RemoteBackend):
 
         bundle_bytes = Path(bundle_path).read_bytes()
         sandbox.fs.upload_file(bundle_bytes, "/workspace/repo.bundle")
-        sandbox.process.exec(
+        _exec_async(
+            sandbox,
+            UPLOAD_SESSION_ID,
             "cd /workspace && git init && git bundle unbundle repo.bundle && rm repo.bundle",
-            cwd="/workspace",
         )
 
         # 2. Upload project files (skip .git — handled by bundle)
@@ -192,7 +230,9 @@ class DaytonaBackend(RemoteBackend):
                     remote_tar = f"/tmp/{mapping.host_path.name}.tar.gz"
                     sandbox.fs.upload_file(tar_bytes, remote_tar)
                     log(f"extracting {mapping.host_path.name}...")
-                    sandbox.process.exec(
+                    _exec_async(
+                        sandbox,
+                        UPLOAD_SESSION_ID,
                         f"mkdir -p {mapping.container_path} && "
                         f"tar xzf {remote_tar} -C /mnt/data/ && "
                         f"rm {remote_tar}",
@@ -206,21 +246,30 @@ class DaytonaBackend(RemoteBackend):
                         sandbox.fs.upload_file(chunk, f"/tmp/chunks/part_{i:010d}")
                         log(f"  chunk {idx + 1}/{n_chunks}")
                     log(f"reassembling chunks...")
-                    sandbox.process.exec(
-                        f"cat /tmp/chunks/part_* > /tmp/combined.tar.gz && "
-                        f"rm -rf /tmp/chunks",
-                        timeout=1200,
+                    _exec_async(
+                        sandbox,
+                        UPLOAD_SESSION_ID,
+                        "cat /tmp/chunks/part_* > /tmp/combined.tar.gz && "
+                        "rm -rf /tmp/chunks",
                     )
                     log(f"extracting {mapping.host_path.name}...")
-                    sandbox.process.exec(
+                    _exec_async(
+                        sandbox,
+                        UPLOAD_SESSION_ID,
                         f"mkdir -p {mapping.container_path} && "
                         f"tar xzf /tmp/combined.tar.gz -C /mnt/data/ && "
                         f"rm -f /tmp/combined.tar.gz",
-                        timeout=1200,
                     )
 
         if container_data_dirs:
             self._path_overrides["data_dirs"] = ",".join(container_data_dirs)
+
+        # Best-effort cleanup of upload session — sandbox tear-down handles it
+        # too, but explicit deletion releases server-side state immediately.
+        try:
+            sandbox.process.delete_session(UPLOAD_SESSION_ID)
+        except Exception:
+            pass
 
     def run(self, cfg: ProjectConfig, extra_args: list[str] | None = None) -> RunInfo:
         from daytona import SessionExecuteRequest

--- a/tests/test_remote_daytona.py
+++ b/tests/test_remote_daytona.py
@@ -45,8 +45,11 @@ def _mock_sandbox():
     sb.id = "sb_test123"
     sb.process.exec.return_value = MagicMock(result="ok")
     sb.process.create_session = MagicMock()
+    sb.process.delete_session = MagicMock()
     sb.process.execute_session_command.return_value = MagicMock(cmd_id="cmd_abc")
-    sb.process.get_session_command.return_value = MagicMock(exit_code=None)
+    # Default to completed/success so _exec_async polling returns immediately.
+    # Tests that need to simulate "still running" override this explicitly.
+    sb.process.get_session_command.return_value = MagicMock(exit_code=0)
     sb.process.get_session_command_logs.return_value = MagicMock(
         output="", stdout="", stderr=""
     )
@@ -498,3 +501,144 @@ def test_remote_env_sets_bypass_permissions(tmp_path):
     assert mock_build.called
     _, kwargs = mock_build.call_args
     assert kwargs["permission_mode"] == "bypassPermissions"
+
+
+# ── _exec_async helper ───────────────────────────────────────────────────────
+
+def test_exec_async_returns_on_success():
+    """Polls until exit_code becomes 0, then returns."""
+    from src.remote.daytona import _exec_async
+
+    sb = _mock_sandbox()
+    sb.process.execute_session_command.return_value = MagicMock(cmd_id="c1")
+    sb.process.get_session_command.side_effect = [
+        MagicMock(exit_code=None),
+        MagicMock(exit_code=None),
+        MagicMock(exit_code=0),
+    ]
+
+    with patch("src.remote.daytona.time.sleep"):
+        _exec_async(sb, "sess", "do something")
+
+    assert sb.process.execute_session_command.called
+    req = sb.process.execute_session_command.call_args[0][1]
+    assert req.run_async is True
+    assert req.command == "do something"
+    assert sb.process.get_session_command.call_count == 3
+
+
+def test_exec_async_raises_on_nonzero_exit():
+    """Includes log tail in the raised error message."""
+    from src.remote.daytona import _exec_async
+
+    sb = _mock_sandbox()
+    sb.process.execute_session_command.return_value = MagicMock(cmd_id="c1")
+    sb.process.get_session_command.return_value = MagicMock(exit_code=2)
+    sb.process.get_session_command_logs.return_value = MagicMock(
+        output="boom: file not found", stdout="", stderr=""
+    )
+
+    with patch("src.remote.daytona.time.sleep"):
+        with pytest.raises(RuntimeError, match="exit=2"):
+            _exec_async(sb, "sess", "bad cmd")
+
+
+def test_exec_async_includes_log_in_error():
+    from src.remote.daytona import _exec_async
+
+    sb = _mock_sandbox()
+    sb.process.execute_session_command.return_value = MagicMock(cmd_id="c1")
+    sb.process.get_session_command.return_value = MagicMock(exit_code=1)
+    sb.process.get_session_command_logs.return_value = MagicMock(
+        output="", stdout="some stdout", stderr="critical stderr msg"
+    )
+
+    with patch("src.remote.daytona.time.sleep"):
+        with pytest.raises(RuntimeError, match="some stdout"):
+            _exec_async(sb, "sess", "bad cmd")
+
+
+def test_exec_async_times_out():
+    """Raises if exit_code never gets set within max_wait_seconds."""
+    from src.remote.daytona import _exec_async
+
+    sb = _mock_sandbox()
+    sb.process.execute_session_command.return_value = MagicMock(cmd_id="c1")
+    sb.process.get_session_command.return_value = MagicMock(exit_code=None)
+
+    with patch("src.remote.daytona.time.sleep"):
+        with pytest.raises(RuntimeError, match="timed out"):
+            _exec_async(sb, "sess", "slow cmd",
+                        poll_interval=0.001, max_wait_seconds=0.01)
+
+
+def test_exec_async_uses_provided_session_id():
+    from src.remote.daytona import _exec_async
+
+    sb = _mock_sandbox()
+    sb.process.execute_session_command.return_value = MagicMock(cmd_id="c1")
+    sb.process.get_session_command.return_value = MagicMock(exit_code=0)
+
+    _exec_async(sb, "my-session", "do it")
+
+    args, _ = sb.process.execute_session_command.call_args
+    assert args[0] == "my-session"
+
+
+# ── Upload uses async session for heavy ops ──────────────────────────────────
+
+def test_upload_creates_upload_session(tmp_path):
+    sb = _mock_sandbox()
+    client = MagicMock()
+    client.create.return_value = sb
+    cfg = _make_cfg(tmp_path)
+
+    with _Patches(client):
+        backend = _setup_backend(client, cfg)
+        backend.upload(cfg)
+
+    create_calls = [c.args for c in sb.process.create_session.call_args_list]
+    assert ("evoskill-upload",) in create_calls
+
+
+def test_upload_dispatches_git_unbundle_via_session(tmp_path):
+    """Git unbundle goes through execute_session_command, not blocking exec."""
+    sb = _mock_sandbox()
+    client = MagicMock()
+    client.create.return_value = sb
+    cfg = _make_cfg(tmp_path)
+
+    with _Patches(client):
+        backend = _setup_backend(client, cfg)
+        backend.upload(cfg)
+
+    # Look for the git unbundle command dispatched via session
+    session_cmds = [
+        call.args[1].command
+        for call in sb.process.execute_session_command.call_args_list
+    ]
+    assert any("git bundle unbundle" in c for c in session_cmds)
+
+
+def test_upload_single_chunk_data_uses_async_for_extract(tmp_path):
+    """Even single-chunk extract goes through async session, not blocking exec."""
+    sb = _mock_sandbox()
+    client = MagicMock()
+    client.create.return_value = sb
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    ext_dir = tmp_path / "external_data"
+    ext_dir.mkdir()
+    (ext_dir / "file.csv").write_text("data")
+    cfg = _make_cfg(project_dir, data_dirs=[str(ext_dir)])
+
+    with _Patches(client):
+        backend = _setup_backend(client, cfg)
+        backend.upload(cfg)
+
+    session_cmds = [
+        call.args[1].command
+        for call in sb.process.execute_session_command.call_args_list
+    ]
+    # Extract command should go through async session
+    assert any("tar xzf /tmp/external_data.tar.gz" in c for c in session_cmds)


### PR DESCRIPTION
Replaces blocking process.exec() calls in upload() with session-based execution (run_async=True + polling). The previous approach held a single HTTP connection open for minutes during cat/tar operations, which the Daytona server reset before the command completed.

The new _exec_async helper submits commands via the session API, returns a cmd_id immediately, then polls get_session_command until exit_code is set. Each HTTP call is short, so connection resets are no longer possible. Caller still blocks synchronously until the command actually completes on the sandbox.

Routed through async helper: git unbundle, single-chunk tar extract, chunked reassembly, chunked tar extract.