### PR TITLE
Accept CLAUDE_CODE_OAUTH_TOKEN for anthropic provider auth

### DIFF
--- a/src/harness/provider_auth.py
+++ b/src/harness/provider_auth.py
@@ -6,7 +6,7 @@ import os
 
 
 PROVIDER_ENV_KEYS: dict[str, tuple[str, ...]] = {
-    "anthropic": ("ANTHROPIC_API_KEY",),
+    "anthropic": ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"),
     "openai": ("OPENAI_API_KEY",),
     "google": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
     "openrouter": ("OPENROUTER_API_KEY", "LLM_API_KEY"),
@@ -49,9 +49,7 @@ def ensure_provider_api_key(provider: str | None) -> str:
 
     expected = " or ".join(env_names)
     display_provider = "OpenRouter" if normalized == "openrouter" else normalized
-    raise RuntimeError(
-        f"{display_provider} API key not configured. Set {expected}."
-    )
+    raise RuntimeError(f"{display_provider} API key not configured. Set {expected}.")
 
 
 def apply_provider_auth_env(provider: str | None, env: dict[str, str]) -> None:


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_CODE_OAUTH_TOKEN` to the anthropic provider's accepted env var list in `src/harness/provider_auth.py`
- Lets Anthropic Pro/Max subscribers run the Claude harness using their existing OAuth credentials, without provisioning a separate API key

## Motivation

`claude-agent-sdk` already reads `CLAUDE_CODE_OAUTH_TOKEN` internally (see `claude_agent_sdk/_internal/session_resume.py`), and the bundled `claude` CLI binary picks up subscription credentials from `~/.claude/.credentials.json`. The only thing blocking subscription users was EvoSkill's own pre-flight `ensure_provider_api_key("anthropic")` check, which hard-required `ANTHROPIC_API_KEY`.

## Scope

This change only touches the `anthropic` entry. Other harnesses (codex / opencode / goose / openhands) bind `api_key` directly into SDK constructors (e.g. `Codex({"api_key": api_key})`, `llm_kwargs["api_key"] = ...`), so OAuth-style credentials don't flow through there — those harnesses are intentionally left unchanged.

## Test plan

- [x] `evoskill --help` still loads after install
- [ ] `evoskill init` → select claude harness → `evoskill run` with only `CLAUDE_CODE_OAUTH_TOKEN` exported (no `ANTHROPIC_API_KEY`)
- [ ] Verify subscription rate limits are observed (vs API metered billing)