### PR TITLE
fix(docker): remove duplicate useradd block

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,10 +69,6 @@ RUN pip install --no-cache-dir \
 RUN useradd -m -s /bin/bash evoskill \
     && mkdir -p /workspace && chown evoskill:evoskill /workspace
 
-# Non-root user
-RUN useradd -m -s /bin/bash evoskill \
-    && mkdir -p /workspace && chown evoskill:evoskill /workspace
-
 # Git config for bundle operations
 RUN git config --global user.email "evoskill@sandbox" \
     && git config --global user.name "EvoSkill Sandbox" \


### PR DESCRIPTION
## Summary
The non-root user setup block is duplicated in the Dockerfile, causing `docker build` to fail at the second `RUN useradd` invocation with:

```
useradd: user 'evoskill' already exists
```

Looks like a regression from #41 (Dockerfile hardening) — the intended single `useradd` block landed alongside the pre-existing one rather than replacing it.

## Change
Remove the duplicate `# Non-root user` block (4 lines).

Closes #42.