### PR TITLE
Feature/continuous evolution

### DIFF
--- a/src/agent_profiles/__init__.py
+++ b/src/agent_profiles/__init__.py
@@ -16,6 +16,7 @@ from .livecodebench_agent import (
 from .prompt_generator import prompt_generator_options
 from .skill_proposer import skill_proposer_options
 from .prompt_proposer import prompt_proposer_options
+from .skill_distiller import skill_distiller_options, make_skill_distiller_options
 
 __all__ = [
     "proposer_options",
@@ -31,4 +32,6 @@ __all__ = [
     "prompt_generator_options",
     "skill_proposer_options",
     "prompt_proposer_options",
+    "skill_distiller_options",
+    "make_skill_distiller_options",
 ]

--- a/src/agent_profiles/__init__.py
+++ b/src/agent_profiles/__init__.py
@@ -17,6 +17,10 @@ from .prompt_generator import prompt_generator_options
 from .skill_proposer import skill_proposer_options
 from .prompt_proposer import prompt_proposer_options
 from .skill_distiller import skill_distiller_options, make_skill_distiller_options
+from .surrogate_verifier import (
+    surrogate_verifier_options,
+    make_surrogate_verifier_options,
+)
 
 __all__ = [
     "proposer_options",
@@ -34,4 +38,6 @@ __all__ = [
     "prompt_proposer_options",
     "skill_distiller_options",
     "make_skill_distiller_options",
+    "surrogate_verifier_options",
+    "make_surrogate_verifier_options",
 ]

--- a/src/agent_profiles/skill_distiller/__init__.py
+++ b/src/agent_profiles/skill_distiller/__init__.py
@@ -1,0 +1,11 @@
+from .skill_distiller import (
+    get_skill_distiller_options,
+    make_skill_distiller_options,
+    skill_distiller_options,
+)
+
+__all__ = [
+    "get_skill_distiller_options",
+    "make_skill_distiller_options",
+    "skill_distiller_options",
+]

--- a/src/agent_profiles/skill_distiller/prompt.py
+++ b/src/agent_profiles/skill_distiller/prompt.py
@@ -1,0 +1,58 @@
+SKILL_DISTILLER_SYSTEM_PROMPT = """
+You distill ONE reusable skill from a cluster of real agent episodes.
+
+You are given several episodes in which an agent attempted *similar* tasks and
+shared the same outcome (usually they all failed in a similar way). Your job is
+to write a single, generalizable skill that would help an agent handle this
+*kind* of task better in the future.
+
+## Critical principle: generalize, do not memorize
+
+The episodes are examples of a recurring pattern, not the thing you are solving.
+- Capture the transferable procedure, rule, or checklist that addresses the
+  shared difficulty.
+- NEVER hard-code a specific answer, value, or task id from the episodes.
+- A good skill helps on unseen tasks of the same shape; a bad skill only "works"
+  on the exact episodes you were shown.
+
+If the episodes do not actually share a generalizable lesson, say so in
+`reasoning` and still produce the most defensible general skill you can.
+
+## Output: a SKILL.md
+
+`candidate_skill` must be a complete SKILL.md starting with YAML frontmatter.
+
+Required frontmatter fields:
+- `name` — must equal `skill_name`, lowercase, hyphen-separated.
+- `description` — one line describing when to use the skill.
+
+Body requirements:
+- Concise and specific. State the reusable rule/procedure.
+- Include 1-3 short, *illustrative* examples (not copied answers).
+- Prefer an actionable checklist or steps over prose.
+
+Example shape:
+
+---
+name: read-financial-tables-precisely
+description: Extract exact figures from tabular financial documents without rounding errors.
+---
+
+## When to use
+When a task asks for a specific figure from a table in a document.
+
+## Steps
+1. Locate the exact row and column ...
+2. Preserve units and signs ...
+3. Re-read the cell before answering ...
+
+## Output behavior
+Return JSON only:
+- `skill_name`: the kebab-case name (matches the frontmatter `name`).
+- `candidate_skill`: the full SKILL.md text.
+- `target_pattern`: the recurring task/failure pattern this skill addresses.
+- `reasoning`: why this generalizes across the cluster rather than memorizing.
+
+Do NOT write any files. You are producing a *candidate* for review, not editing
+the live skill library.
+""".strip()

--- a/src/agent_profiles/skill_distiller/skill_distiller.py
+++ b/src/agent_profiles/skill_distiller/skill_distiller.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.harness import build_options
+from src.schemas import SkillDistillerResponse
+from src.agent_profiles.skill_distiller.prompt import SKILL_DISTILLER_SYSTEM_PROMPT
+
+
+# Read-only toolset by design: the distiller produces a *candidate* skill string
+# for the review buffer and must never touch the live `.claude/skills/` library
+# (no Write/Edit). Graduation into the library happens later, through the gate.
+SKILL_DISTILLER_TOOLS = [
+    "Read",
+    "Bash",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "TodoWrite",
+    "BashOutput",
+]
+
+
+def get_skill_distiller_options(
+    model: str | None = None,
+    project_root: str | Path | None = None,
+) -> Any:
+    return build_options(
+        system=SKILL_DISTILLER_SYSTEM_PROMPT.strip(),
+        schema=SkillDistillerResponse.model_json_schema(),
+        tools=SKILL_DISTILLER_TOOLS,
+        project_root=project_root,
+        model=model,
+    )
+
+
+def make_skill_distiller_options(
+    *,
+    project_root: str | Path | None = None,
+    model: str | None = None,
+):
+    return get_skill_distiller_options(model=model, project_root=project_root)
+
+
+skill_distiller_options = get_skill_distiller_options()

--- a/src/agent_profiles/surrogate_verifier/__init__.py
+++ b/src/agent_profiles/surrogate_verifier/__init__.py
@@ -1,0 +1,11 @@
+from .surrogate_verifier import (
+    get_surrogate_verifier_options,
+    make_surrogate_verifier_options,
+    surrogate_verifier_options,
+)
+
+__all__ = [
+    "get_surrogate_verifier_options",
+    "make_surrogate_verifier_options",
+    "surrogate_verifier_options",
+]

--- a/src/agent_profiles/surrogate_verifier/prompt.py
+++ b/src/agent_profiles/surrogate_verifier/prompt.py
@@ -1,0 +1,38 @@
+SURROGATE_VERIFIER_SYSTEM_PROMPT = """
+You are an independent verifier judging whether a CANDIDATE skill should be
+admitted to an agent's skill library.
+
+You work in isolation: you do NOT know how the skill was written or what
+training examples produced it. Judge it only on its own merits and on the
+held-out task descriptions you are given.
+
+## Your job
+
+1. Read the candidate SKILL.md.
+2. Read the held-out task descriptions (these are tasks the skill was NOT
+   distilled from — they test generalization). You are given the tasks only,
+   never their answers.
+3. Synthesize concrete assertions the skill must satisfy to be trustworthy,
+   e.g.:
+   - "States a general, reusable rule rather than a specific memorized answer."
+   - "Would plausibly help on the held-out tasks of this kind."
+   - "Does not hard-code values, ids, or answers from any particular task."
+   - "Is internally consistent and unambiguous."
+4. Decide.
+
+## Bias toward rejection on doubt
+
+A skill that overfits (memorizes specifics, helps only the exact examples,
+hard-codes answers) must FAIL. When uncertain whether a skill generalizes,
+prefer verdict=false. The library's quality matters more than its size.
+
+## Output
+
+Return JSON only:
+- `score`: float in [0,1] — your confidence the skill is correct AND generalizes.
+- `verdict`: boolean — true only if it clearly should be admitted.
+- `assertions`: the list of checks you synthesized and applied.
+- `reasoning`: concise diagnostics — what passed, what failed, and why.
+
+Do NOT write any files.
+""".strip()

--- a/src/agent_profiles/surrogate_verifier/surrogate_verifier.py
+++ b/src/agent_profiles/surrogate_verifier/surrogate_verifier.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.harness import build_options
+from src.schemas import SurrogateVerifierResponse
+from src.agent_profiles.surrogate_verifier.prompt import SURROGATE_VERIFIER_SYSTEM_PROMPT
+
+
+# Read-only by design: the verifier judges a candidate string; it must never
+# modify the skill library. Information isolation (no Write/Edit, fresh session)
+# is what keeps its verdict independent of how the skill was produced.
+SURROGATE_VERIFIER_TOOLS = [
+    "Read",
+    "Bash",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "TodoWrite",
+    "BashOutput",
+]
+
+
+def get_surrogate_verifier_options(
+    model: str | None = None,
+    project_root: str | Path | None = None,
+) -> Any:
+    return build_options(
+        system=SURROGATE_VERIFIER_SYSTEM_PROMPT.strip(),
+        schema=SurrogateVerifierResponse.model_json_schema(),
+        tools=SURROGATE_VERIFIER_TOOLS,
+        project_root=project_root,
+        model=model,
+    )
+
+
+def make_surrogate_verifier_options(
+    *,
+    project_root: str | Path | None = None,
+    model: str | None = None,
+):
+    return get_surrogate_verifier_options(model=model, project_root=project_root)
+
+
+surrogate_verifier_options = get_surrogate_verifier_options()

--- a/src/cli/commands/candidates.py
+++ b/src/cli/commands/candidates.py
@@ -1,0 +1,62 @@
+"""evoskill candidates — list and inspect harvested candidate skills."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.syntax import Syntax
+from rich.table import Table
+
+console = Console()
+
+
+@click.command("candidates")
+@click.option("--show", "show_id", default=None, help="Print the full SKILL.md for a candidate id.")
+@click.option("--status", "status_filter", type=click.Choice(["pending", "graduated", "rejected"]),
+              default=None, help="Only show candidates with this status.")
+@click.option("--config", "config_path", type=click.Path(dir_okay=False, path_type=Path),
+              default=None, help="Load a specific config TOML file.")
+def candidates_cmd(show_id, status_filter, config_path):
+    """List buffered candidate skills produced by `evoskill harvest`."""
+    from src.cli.config import load_config
+    from src.continuous import CandidateStore
+
+    cfg = load_config(config_path=config_path)
+    store = CandidateStore(cfg.continuous_candidates_dir)
+
+    if show_id:
+        candidate = store.get(show_id)
+        if candidate is None:
+            console.print(f"[red]Error:[/red] no candidate '{show_id}'.")
+            raise SystemExit(1)
+        console.print(f"\n  [bold]{candidate.skill_name}[/bold]  ({candidate.candidate_id})")
+        console.print(f"  pattern: {candidate.target_pattern}")
+        console.print(f"  from {candidate.cluster_size} '{candidate.outcome_focus}' episodes  "
+                      f"| status: {candidate.status}\n")
+        console.print(Syntax(candidate.skill_markdown, "markdown", theme="ansi_dark"))
+        return
+
+    candidates = store.list()
+    if status_filter:
+        candidates = [c for c in candidates if c.status == status_filter]
+
+    if not candidates:
+        console.print("  No candidates yet. Run [bold]evoskill harvest[/bold] first.")
+        return
+
+    table = Table(box=None, pad_edge=False, show_header=True, header_style="bold")
+    table.add_column("Candidate id", min_width=24)
+    table.add_column("Skill", min_width=20)
+    table.add_column("Size", width=5)
+    table.add_column("Status", width=10)
+    table.add_column("Pattern")
+    for c in candidates:
+        table.add_row(
+            c.candidate_id, c.skill_name, str(c.cluster_size), c.status,
+            (c.target_pattern or "")[:50],
+        )
+    console.print(table)
+    console.print(f"\n  {len(candidates)} candidate(s). "
+                  "Inspect one with [bold]evoskill candidates --show <id>[/bold].\n")

--- a/src/cli/commands/graduate.py
+++ b/src/cli/commands/graduate.py
@@ -1,0 +1,124 @@
+"""evoskill graduate / reject — promote (or discard) a candidate skill.
+
+`evoskill graduate <id>` runs the quality gate (surrogate verifier on a held-out
+replay buffer) and, on pass, installs the skill into the live library and
+snapshots a `program/*` branch. `--force` skips the gate; `--no-branch` installs
+without creating a git branch.
+
+`evoskill reject <id>` marks a candidate rejected without touching the library.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+console = Console()
+
+
+@click.command("graduate")
+@click.argument("candidate_id")
+@click.option("--force", is_flag=True, default=False, help="Skip the gate and graduate anyway.")
+@click.option("--no-branch", is_flag=True, default=False,
+              help="Install the skill without creating a program/* branch.")
+@click.option("--config", "config_path", type=click.Path(dir_okay=False, path_type=Path),
+              default=None, help="Load a specific config TOML file.")
+def graduate_cmd(candidate_id, force, no_branch, config_path):
+    """Run the gate and graduate a candidate into the live skill library."""
+    from src.cli.config import load_config
+    from src.continuous import (
+        CandidateStore,
+        SurrogateEvaluator,
+        TraceCollector,
+        build_readers,
+        build_replay_buffer,
+        graduate,
+        run_gate,
+    )
+
+    cfg = load_config(config_path=config_path)
+    store = CandidateStore(cfg.continuous_candidates_dir)
+    candidate = store.get(candidate_id)
+    if candidate is None:
+        console.print(f"[red]Error:[/red] no candidate '{candidate_id}'.")
+        raise SystemExit(1)
+
+    gate_score = None
+    if not force:
+        from src.harness import Agent, set_sdk
+        from src.agent_profiles import make_surrogate_verifier_options
+        from src.schemas import SurrogateVerifierResponse
+
+        set_sdk(cfg.harness.name)
+        readers = build_readers(
+            cfg.continuous.trace_sources,
+            traces_root=str(cfg.continuous_traces_root),
+            jsonl_path=cfg.continuous.jsonl_path or None,
+            success_threshold=cfg.continuous.success_threshold,
+        )
+        episodes = TraceCollector(readers).collect(advance=False, limit=cfg.continuous.harvest_window)
+        replay = build_replay_buffer(episodes, candidate, size=cfg.continuous.shadow_eval_size)
+
+        verifier = Agent(
+            make_surrogate_verifier_options(
+                model=cfg.continuous.surrogate_model or cfg.harness.model,
+                project_root=str(cfg.project_root),
+            ),
+            SurrogateVerifierResponse,
+        )
+        verdict = asyncio.run(run_gate(
+            candidate, replay, SurrogateEvaluator(verifier),
+            threshold=cfg.continuous.graduation_threshold,
+        ))
+        gate_score = verdict.score
+        console.print(
+            f"\n  Gate ({verdict.method}): score={verdict.score:.2f} "
+            f"threshold={verdict.threshold:.2f} on {verdict.n_tasks} held-out task(s) "
+            f"→ {'[green]PASS[/green]' if verdict.passed else '[red]FAIL[/red]'}"
+        )
+        if verdict.detail:
+            console.print(f"  [dim]{verdict.detail[:300]}[/dim]")
+        if not verdict.passed:
+            console.print("\n  Not graduated. Re-run with --force to override.\n")
+            raise SystemExit(1)
+
+    manager = None
+    if not no_branch:
+        from src.registry import ProgramManager
+        manager = ProgramManager(cwd=cfg.project_root)
+
+    result = graduate(
+        candidate,
+        skills_dir=cfg.skills_dir,
+        store=store,
+        manager=manager,
+        archive_dir=cfg.continuous_deprecated_dir,
+        gate_score=gate_score,
+    )
+    console.print(f"\n  [green]Graduated[/green] '{result.skill_name}' → {result.installed_path}")
+    if result.branch:
+        console.print(f"  Branch: {result.branch}")
+    if result.archived_originals:
+        console.print(f"  Archived merged originals: {', '.join(result.archived_originals)}")
+    console.print()
+
+
+@click.command("reject")
+@click.argument("candidate_id")
+@click.option("--config", "config_path", type=click.Path(dir_okay=False, path_type=Path),
+              default=None, help="Load a specific config TOML file.")
+def reject_cmd(candidate_id, config_path):
+    """Mark a candidate rejected (no change to the library)."""
+    from src.cli.config import load_config
+    from src.continuous import CandidateStore
+
+    cfg = load_config(config_path=config_path)
+    store = CandidateStore(cfg.continuous_candidates_dir)
+    updated = store.set_status(candidate_id, "rejected")
+    if updated is None:
+        console.print(f"[red]Error:[/red] no candidate '{candidate_id}'.")
+        raise SystemExit(1)
+    console.print(f"  Rejected '{candidate_id}'.")

--- a/src/cli/commands/harvest.py
+++ b/src/cli/commands/harvest.py
@@ -1,0 +1,152 @@
+"""evoskill harvest — distill candidate skills from real usage traces.
+
+Offline Phase-1 entry point for continuous evolution: collect a window of agent
+trajectories, cluster recurring failures (or successes), and distill one
+reusable candidate skill per cluster into the review buffer. Candidates are NOT
+added to the live skill library — review them with `evoskill candidates`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+_FOCUS_TO_OUTCOME = {"failure": "FAILURE", "success": "SUCCESS"}
+
+
+@click.command("harvest")
+@click.option("--traces", "traces_root", type=click.Path(path_type=Path), default=None,
+              help="Trace root to harvest (default: configured harbor jobs dir).")
+@click.option("--source", "sources", multiple=True,
+              type=click.Choice(["harbor", "goose", "jsonl"]),
+              help="Trace source(s) to read. Repeatable. Default: config.")
+@click.option("--window", type=int, default=None, help="Max episodes to collect.")
+@click.option("--min-cluster-size", type=int, default=None,
+              help="Minimum episodes per cluster to distill a candidate.")
+@click.option("--max-candidates", type=int, default=None,
+              help="Cap the number of candidates distilled (largest clusters first).")
+@click.option("--focus", type=click.Choice(["failure", "success", "both"]), default=None,
+              help="Mine failures (capability gaps), successes, or both.")
+@click.option("--dry-run", is_flag=True, default=False,
+              help="Cluster only — no LLM distillation, no candidates written.")
+@click.option("--config", "config_path", type=click.Path(dir_okay=False, path_type=Path),
+              default=None, help="Load a specific config TOML file.")
+def harvest_cmd(traces_root, sources, window, min_cluster_size, max_candidates,
+                focus, dry_run, config_path):
+    """Distill candidate skills from a window of usage traces."""
+    from src.cli.config import load_config
+    from src.continuous import (
+        CandidateStore,
+        Outcome,
+        TraceCollector,
+        build_readers,
+        cluster_episodes,
+        harvest as run_harvest,
+    )
+
+    cfg = load_config(config_path=config_path)
+    cont = cfg.continuous
+
+    # Resolve effective parameters (CLI overrides config).
+    src_list = list(sources) if sources else cont.trace_sources
+    root = str(traces_root) if traces_root else str(cfg.continuous_traces_root)
+    window = window if window is not None else cont.harvest_window
+    min_cluster_size = min_cluster_size if min_cluster_size is not None else cont.min_cluster_size
+    max_candidates = max_candidates if max_candidates is not None else cont.max_candidates
+    focus = focus or cont.focus
+
+    readers = build_readers(
+        src_list,
+        traces_root=root,
+        jsonl_path=cont.jsonl_path or None,
+        success_threshold=cont.success_threshold,
+    )
+    if not readers:
+        console.print(
+            f"[red]Error:[/red] no usable trace sources for {src_list} at [bold]{root}[/bold].\n"
+            "  Point --traces at a Harbor jobs dir, or set [continuous].jsonl_path."
+        )
+        raise SystemExit(1)
+
+    focuses = [Outcome.FAILURE, Outcome.SUCCESS] if focus == "both" else [
+        getattr(Outcome, _FOCUS_TO_OUTCOME[focus])
+    ]
+
+    console.print(
+        f"\n  [bold]EvoSkill harvest[/bold] — sources={src_list}  focus={focus}  "
+        f"window={window}  min_cluster={min_cluster_size}\n  traces: {root}\n"
+    )
+
+    # ── dry run: collect + cluster only ──
+    if dry_run:
+        episodes = TraceCollector(readers).collect(advance=False, limit=window)
+        console.print(f"  Collected {len(episodes)} episode(s).")
+        for foc in focuses:
+            clusters = cluster_episodes(
+                episodes, focus=foc, min_cluster_size=min_cluster_size,
+                similarity_threshold=cont.similarity_threshold, max_clusters=max_candidates,
+            )
+            _print_clusters(foc.value, clusters)
+        console.print("\n  [dim]dry-run: no candidates written[/dim]\n")
+        return
+
+    # ── full harvest: distill + write candidates ──
+    from src.harness import Agent, set_sdk
+    from src.agent_profiles import make_skill_distiller_options
+    from src.schemas import SkillDistillerResponse
+
+    set_sdk(cfg.harness.name)
+    distiller = Agent(
+        make_skill_distiller_options(
+            model=cont.distiller_model or cfg.harness.model,
+            project_root=str(cfg.project_root),
+        ),
+        SkillDistillerResponse,
+    )
+    store = CandidateStore(cfg.continuous_candidates_dir)
+
+    total_candidates = 0
+    for foc in focuses:
+        result = asyncio.run(
+            run_harvest(
+                readers=readers,
+                distiller=distiller,
+                store=store,
+                window=window,
+                min_cluster_size=min_cluster_size,
+                similarity_threshold=cont.similarity_threshold,
+                focus=foc,
+                max_candidates=max_candidates,
+                concurrency=cont.concurrency,
+                advance_cursor=False,
+                log=lambda msg: console.print(f"  {msg}"),
+            )
+        )
+        total_candidates += result.num_candidates
+
+    console.print(
+        f"\n  Wrote [bold]{total_candidates}[/bold] candidate(s) to "
+        f"{cfg.continuous_candidates_dir}\n"
+        "  Review with [bold]evoskill candidates[/bold].\n"
+    )
+
+
+def _print_clusters(focus: str, clusters) -> None:
+    if not clusters:
+        console.print(f"  No '{focus}' clusters met the threshold.")
+        return
+    table = Table(box=None, pad_edge=False, show_header=True, header_style="bold",
+                  title=f"{focus} clusters")
+    table.add_column("Size", width=6)
+    table.add_column("Top terms")
+    table.add_column("Example task")
+    for c in clusters:
+        example = c.episodes[0].task_text[:60].replace("\n", " ") if c.episodes else ""
+        table.add_row(str(c.size), ", ".join(c.top_terms[:5]), example)
+    console.print(table)

--- a/src/cli/commands/library.py
+++ b/src/cli/commands/library.py
@@ -1,0 +1,124 @@
+"""evoskill library — inspect and curate the skill library.
+
+Surfaces the Phase 2 lifecycle operations:
+  evoskill library                     list skills + usage/credit stats
+  evoskill library --duplicates        find near-duplicate skills
+  evoskill library --select "<task>"   preview which skills a task would load
+  evoskill library --deprecated        list archived skills
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+
+def _similarity_backend(cfg):
+    """Build the configured similarity backend, resolving the embedding API key."""
+    from src.continuous import make_similarity_backend
+    from src.harness.provider_auth import resolve_provider_api_key
+
+    lc = cfg.continuous.lifecycle
+    api_key, _ = resolve_provider_api_key(lc.embedding_provider)
+    return make_similarity_backend(
+        backend=lc.similarity_backend,
+        provider=lc.embedding_provider,
+        model=lc.embedding_model,
+        api_key=api_key,
+        cache_path=str(cfg.continuous_embeddings_cache_path),
+        log=lambda m: console.print(f"  [dim]{m}[/dim]"),
+    )
+
+
+@click.command("library")
+@click.option("--duplicates", is_flag=True, default=False, help="Find near-duplicate skills.")
+@click.option("--select", "select_task", default=None, help="Preview top-k skills for a task.")
+@click.option("--deprecated", is_flag=True, default=False, help="List archived/deprecated skills.")
+@click.option("--config", "config_path", type=click.Path(dir_okay=False, path_type=Path),
+              default=None, help="Load a specific config TOML file.")
+def library_cmd(duplicates, select_task, deprecated, config_path):
+    """Inspect and curate the live skill library."""
+    from src.cli.config import load_config
+    from src.continuous import (
+        SkillLibrary,
+        SkillStatsStore,
+        find_duplicates,
+        select_skills,
+    )
+
+    cfg = load_config(config_path=config_path)
+    library = SkillLibrary(cfg.skills_dir)
+    skills = library.list()
+
+    if deprecated:
+        _list_deprecated(cfg)
+        return
+
+    if not skills:
+        console.print("  No skills yet. Run [bold]evoskill run[/bold] or graduate candidates first.")
+        return
+
+    if select_task:
+        backend = _similarity_backend(cfg)
+        matches = select_skills(skills, select_task, backend, k=cfg.continuous.lifecycle.retrieval_top_k)
+        table = Table(box=None, pad_edge=False, show_header=True, header_style="bold",
+                      title=f"Top skills for: {select_task[:50]}")
+        table.add_column("Score", width=7)
+        table.add_column("Skill")
+        table.add_column("Description")
+        for m in matches:
+            table.add_row(f"{m.score:.3f}", m.skill.name, (m.skill.description or "")[:60])
+        console.print(table)
+        return
+
+    if duplicates:
+        backend = _similarity_backend(cfg)
+        groups = find_duplicates(skills, backend, threshold=cfg.continuous.lifecycle.dedupe_similarity)
+        if not groups:
+            console.print(f"  No near-duplicates above {cfg.continuous.lifecycle.dedupe_similarity}.")
+            return
+        for g in groups:
+            console.print(f"\n  [bold]similar ({g.max_similarity:.3f})[/bold]: "
+                          f"{', '.join(g.names)}")
+        console.print("\n  [dim]Merge proposals/graduation come with the gate (Phase 3).[/dim]\n")
+        return
+
+    # Default: list skills with stats.
+    stats_store = SkillStatsStore(cfg.continuous_skill_stats_path)
+    table = Table(box=None, pad_edge=False, show_header=True, header_style="bold")
+    table.add_column("Skill", min_width=24)
+    table.add_column("Used", width=6)
+    table.add_column("Wins", width=6)
+    table.add_column("Contrib", width=8)
+    table.add_column("Strikes", width=8)
+    table.add_column("Description")
+    for s in skills:
+        st = stats_store.get(s.name) if stats_store.has(s.name) else None
+        table.add_row(
+            s.name,
+            str(st.episodes_active) if st else "0",
+            str(st.success_when_active) if st else "0",
+            f"{st.contribution:.2f}" if st else "0.00",
+            str(st.deprecation_strikes) if st else "0",
+            (s.description or "")[:50],
+        )
+    console.print(table)
+    console.print(f"\n  {len(skills)} skill(s) in {cfg.skills_dir}\n")
+
+
+def _list_deprecated(cfg) -> None:
+    archive = cfg.continuous_deprecated_dir
+    if not archive.is_dir() or not any(archive.iterdir()):
+        console.print("  No deprecated skills.")
+        return
+    table = Table(box=None, pad_edge=False, show_header=True, header_style="bold")
+    table.add_column("Archived skill")
+    for child in sorted(archive.iterdir()):
+        if child.is_dir():
+            table.add_row(child.name)
+    console.print(table)

--- a/src/cli/commands/watch.py
+++ b/src/cli/commands/watch.py
@@ -1,0 +1,154 @@
+"""evoskill watch — the always-on continuous-evolution daemon.
+
+Repeats one `run_tick` (collect → credit → cluster → distill → [auto: gate →
+graduate] → deprecation → watermark) on a schedule. `review` mode (default) only
+discovers candidates; `auto` mode gates and graduates them with safety rails
+(dedup-guard, rate limit, cost ceiling).
+
+    evoskill watch              # loop forever (Ctrl-C to stop)
+    evoskill watch --once       # a single tick (good for cron / testing)
+    evoskill watch --max-ticks 5
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+console = Console()
+
+_FOCUS = {"failure": "FAILURE", "success": "SUCCESS", "both": "FAILURE"}
+
+
+@click.command("watch")
+@click.option("--once", is_flag=True, default=False, help="Run a single tick and exit.")
+@click.option("--max-ticks", type=int, default=None, help="Stop after this many ticks.")
+@click.option("--interval", "interval_sec", type=int, default=None,
+              help="Seconds between ticks (overrides config poll_interval_sec).")
+@click.option("--mode", type=click.Choice(["review", "auto"]), default=None,
+              help="Override graduation mode for this run.")
+@click.option("--config", "config_path", type=click.Path(dir_okay=False, path_type=Path),
+              default=None, help="Load a specific config TOML file.")
+def watch_cmd(once, max_ticks, interval_sec, mode, config_path):
+    """Run the continuous-evolution daemon."""
+    from src.cli.config import load_config
+    from src.continuous import (
+        CandidateStore,
+        Outcome,
+        SkillStatsStore,
+        TickConfig,
+        TraceCursor,
+        build_readers,
+        make_similarity_backend,
+        run_tick,
+        run_watch_loop,
+    )
+    from src.harness import Agent, set_sdk
+
+    cfg = load_config(config_path=config_path)
+    cont = cfg.continuous
+    mode = mode or cont.graduation_mode
+    set_sdk(cfg.harness.name)
+
+    readers = build_readers(
+        cont.trace_sources,
+        traces_root=str(cfg.continuous_traces_root),
+        jsonl_path=cont.jsonl_path or None,
+        success_threshold=cont.success_threshold,
+    )
+    if not readers:
+        console.print(
+            f"[red]Error:[/red] no usable trace sources for {cont.trace_sources} "
+            f"at {cfg.continuous_traces_root}."
+        )
+        raise SystemExit(1)
+
+    from src.agent_profiles import make_skill_distiller_options
+    from src.schemas import SkillDistillerResponse
+
+    distiller = Agent(
+        make_skill_distiller_options(
+            model=cont.distiller_model or cfg.harness.model, project_root=str(cfg.project_root)),
+        SkillDistillerResponse,
+    )
+
+    cursor = TraceCursor(cfg.evoskill_dir / "continuous" / "cursor.json")
+    store = CandidateStore(cfg.continuous_candidates_dir)
+    stats_store = SkillStatsStore(cfg.continuous_skill_stats_path)
+
+    tick_config = TickConfig(
+        mode=mode,
+        window=cont.harvest_window,
+        focus=getattr(Outcome, _FOCUS[cont.focus]),
+        min_cluster_size=cont.min_cluster_size,
+        similarity_threshold=cont.similarity_threshold,
+        max_candidates=cont.max_candidates,
+        concurrency=cont.concurrency,
+        graduation_threshold=cont.graduation_threshold,
+        shadow_eval_size=cont.shadow_eval_size,
+        max_graduations=cont.max_graduations_per_window,
+        dedupe_similarity=cont.lifecycle.dedupe_similarity,
+        deprecation_baseline=cont.lifecycle.deprecation_baseline,
+        deprecation_strikes=cont.lifecycle.deprecation_strikes,
+        auto_deprecate=cont.auto_deprecate,
+        cost_ceiling=cont.cost_ceiling_usd_per_tick or None,
+    )
+
+    # Gate/graduation collaborators are only needed in auto mode.
+    verifier = None
+    manager = None
+    similarity_backend = None
+    if mode == "auto":
+        from src.agent_profiles import make_surrogate_verifier_options
+        from src.harness.provider_auth import resolve_provider_api_key
+        from src.registry import ProgramManager
+        from src.schemas import SurrogateVerifierResponse
+
+        verifier = Agent(
+            make_surrogate_verifier_options(
+                model=cont.surrogate_model or cfg.harness.model, project_root=str(cfg.project_root)),
+            SurrogateVerifierResponse,
+        )
+        manager = ProgramManager(cwd=cfg.project_root)
+        api_key, _ = resolve_provider_api_key(cont.lifecycle.embedding_provider)
+        similarity_backend = make_similarity_backend(
+            backend=cont.lifecycle.similarity_backend,
+            provider=cont.lifecycle.embedding_provider,
+            model=cont.lifecycle.embedding_model,
+            api_key=api_key,
+            cache_path=str(cfg.continuous_embeddings_cache_path),
+        )
+
+    interval = interval_sec if interval_sec is not None else cont.poll_interval_sec
+    console.print(
+        f"\n  [bold]EvoSkill watch[/bold] — mode={mode}  interval={interval}s  "
+        f"traces={cfg.continuous_traces_root}\n"
+    )
+
+    def _one_tick():
+        report = asyncio.run(run_tick(
+            readers=readers, store=store, distiller=distiller, cursor=cursor,
+            verifier=verifier, skills_dir=cfg.skills_dir, stats_store=stats_store,
+            similarity_backend=similarity_backend, manager=manager,
+            archive_dir=cfg.continuous_deprecated_dir, config=tick_config,
+            log=lambda m: console.print(f"  {m}"),
+        ))
+        summary = (f"tick: {report.episodes_collected} episodes, "
+                   f"{report.num_candidates} candidate(s)")
+        if mode == "auto":
+            summary += f", {report.num_graduated} graduated"
+            if report.skipped_duplicates:
+                summary += f", {len(report.skipped_duplicates)} dup-skipped"
+            if report.stopped_reason:
+                summary += f" [stopped: {report.stopped_reason}]"
+        console.print(f"  [green]{summary}[/green]  (${report.cost_usd:.4f})")
+        return report
+
+    ticks = run_watch_loop(
+        _one_tick, once=once, max_ticks=max_ticks, interval_sec=interval,
+        log=lambda m: console.print(f"  {m}"),
+    )
+    console.print(f"\n  Ran {ticks} tick(s).\n")

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -84,11 +84,23 @@ class HarborConfig:
 
 
 @dataclass
+class LifecycleConfig:
+    """Skill-library lifecycle management ([continuous.lifecycle])."""
+    similarity_backend: Literal['embedding', 'lexical'] = 'embedding'
+    embedding_provider: str = 'openai'          # OpenAI-compatible; else falls back to lexical
+    embedding_model: str = 'text-embedding-3-small'
+    dedupe_similarity: float = 0.88             # cosine threshold for "redundant"
+    deprecation_baseline: float = 0.0           # contribution floor
+    deprecation_strikes: int = 3                # windows below floor before retiring
+    retrieval_top_k: int = 6                    # skills to surface per task
+
+
+@dataclass
 class ContinuousConfig:
     """Continuous evolution: learn skills from real usage traces.
 
-    Phase 1 (harvest) uses the harvest-relevant fields below. Later phases add
-    graduation/lifecycle/signal settings to this same section.
+    Phase 1 (harvest) uses the harvest-relevant fields below; Phase 2 adds the
+    nested `lifecycle` section. Later phases add graduation/signal settings here.
     """
     enabled: bool = False
     trace_sources: list[str] = field(default_factory=lambda: ['harbor'])  # harbor | goose | jsonl
@@ -102,6 +114,7 @@ class ContinuousConfig:
     distiller_model: str | None = None    # defaults to harness.model
     concurrency: int = 4                  # parallel distiller calls
     success_threshold: float = 1.0        # verifier reward >= this counts as success
+    lifecycle: LifecycleConfig = field(default_factory=LifecycleConfig)
 
 
 @dataclass
@@ -197,6 +210,23 @@ class ProjectConfig:
     def continuous_candidates_dir(self) -> Path:
         """Where harvested candidate skills are buffered for review."""
         return self.evoskill_dir / 'continuous' / 'candidates'
+
+    @property
+    def skills_dir(self) -> Path:
+        """The live skill library."""
+        return self.project_root / '.claude' / 'skills'
+
+    @property
+    def continuous_skill_stats_path(self) -> Path:
+        return self.evoskill_dir / 'continuous' / 'skill_stats.json'
+
+    @property
+    def continuous_embeddings_cache_path(self) -> Path:
+        return self.evoskill_dir / 'continuous' / 'embeddings_cache.json'
+
+    @property
+    def continuous_deprecated_dir(self) -> Path:
+        return self.evoskill_dir / 'continuous' / 'deprecated'
 
 
 def _find_project_root(start: Path | None = None) -> Path | None:
@@ -314,9 +344,13 @@ def load_config(
     harbor_raw = dict(raw.get('harbor', {}))
     harbor = HarborConfig(**harbor_raw) if harbor_raw else HarborConfig()
 
-    # Parse [continuous] section (optional)
+    # Parse [continuous] section (optional), including the nested
+    # [continuous.lifecycle] table.
     continuous_raw = dict(raw.get('continuous', {}))
+    lifecycle_raw = continuous_raw.pop('lifecycle', None)
     continuous = ContinuousConfig(**continuous_raw) if continuous_raw else ContinuousConfig()
+    if lifecycle_raw:
+        continuous.lifecycle = LifecycleConfig(**lifecycle_raw)
 
     return ProjectConfig(
         harness=harness,

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -120,6 +120,10 @@ class ContinuousConfig:
     shadow_eval_size: int = 10            # held-out tasks shown to the verifier
     max_graduations_per_window: int = 2   # rate limit (used by the watch daemon)
     surrogate_model: str | None = None    # defaults to harness.model
+    # Watch daemon (Phase 4)
+    poll_interval_sec: int = 600          # seconds between watch ticks
+    cost_ceiling_usd_per_tick: float = 0.0  # 0 = unlimited; else stop a tick past this spend
+    auto_deprecate: bool = False          # in auto mode, archive skills past the strike limit
     lifecycle: LifecycleConfig = field(default_factory=LifecycleConfig)
 
 

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -84,6 +84,27 @@ class HarborConfig:
 
 
 @dataclass
+class ContinuousConfig:
+    """Continuous evolution: learn skills from real usage traces.
+
+    Phase 1 (harvest) uses the harvest-relevant fields below. Later phases add
+    graduation/lifecycle/signal settings to this same section.
+    """
+    enabled: bool = False
+    trace_sources: list[str] = field(default_factory=lambda: ['harbor'])  # harbor | goose | jsonl
+    traces_root: str = ''                 # override; default <project>/.evoskill/harbor_jobs
+    jsonl_path: str = ''                  # path for the 'jsonl' source
+    harvest_window: int = 200             # max episodes per harvest
+    min_cluster_size: int = 3             # episodes needed to justify a candidate
+    similarity_threshold: float = 0.3     # cosine threshold for clustering
+    max_candidates: int | None = None     # cap clusters distilled per harvest
+    focus: Literal['failure', 'success', 'both'] = 'failure'
+    distiller_model: str | None = None    # defaults to harness.model
+    concurrency: int = 4                  # parallel distiller calls
+    success_threshold: float = 1.0        # verifier reward >= this counts as success
+
+
+@dataclass
 class ScorerConfig:
     type: Literal['exact', 'multi_tolerance', 'llm', 'script', 'harbor'] = 'multi_tolerance'
     rubric: str | None = None
@@ -128,6 +149,7 @@ class ProjectConfig:
     scorer: ScorerConfig = field(default_factory=ScorerConfig)
     remote: RemoteConfig | None = None
     harbor: HarborConfig = field(default_factory=HarborConfig)
+    continuous: ContinuousConfig = field(default_factory=ContinuousConfig)
     execution: str = 'local'  # 'local', 'docker', or 'daytona'
     project_root: Path = field(default_factory=Path.cwd)
     task_description: str = ''
@@ -154,6 +176,27 @@ class ProjectConfig:
             return Path(override)
         path = Path(self.dataset.harbor_tasks_root)
         return path if path.is_absolute() else self.project_root / path
+
+    @property
+    def harbor_jobs_dir(self) -> Path:
+        """Where Harbor trial output (incl. trajectory.json) is written."""
+        if self.harbor.jobs_dir:
+            path = Path(self.harbor.jobs_dir)
+            return path if path.is_absolute() else self.project_root / path
+        return self.evoskill_dir / 'harbor_jobs'
+
+    @property
+    def continuous_traces_root(self) -> Path:
+        """Default trace root for continuous harvest (Harbor job output)."""
+        if self.continuous.traces_root:
+            path = Path(self.continuous.traces_root)
+            return path if path.is_absolute() else self.project_root / path
+        return self.harbor_jobs_dir
+
+    @property
+    def continuous_candidates_dir(self) -> Path:
+        """Where harvested candidate skills are buffered for review."""
+        return self.evoskill_dir / 'continuous' / 'candidates'
 
 
 def _find_project_root(start: Path | None = None) -> Path | None:
@@ -271,6 +314,10 @@ def load_config(
     harbor_raw = dict(raw.get('harbor', {}))
     harbor = HarborConfig(**harbor_raw) if harbor_raw else HarborConfig()
 
+    # Parse [continuous] section (optional)
+    continuous_raw = dict(raw.get('continuous', {}))
+    continuous = ContinuousConfig(**continuous_raw) if continuous_raw else ContinuousConfig()
+
     return ProjectConfig(
         harness=harness,
         evolution=evolution,
@@ -278,6 +325,7 @@ def load_config(
         scorer=scorer,
         remote=remote,
         harbor=harbor,
+        continuous=continuous,
         execution=execution,
         project_root=root,
         task_description=description,

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -114,6 +114,12 @@ class ContinuousConfig:
     distiller_model: str | None = None    # defaults to harness.model
     concurrency: int = 4                  # parallel distiller calls
     success_threshold: float = 1.0        # verifier reward >= this counts as success
+    # Graduation / gate (Phase 3)
+    graduation_mode: Literal['review', 'auto'] = 'review'  # 'review' = human applies; 'auto' = gate applies
+    graduation_threshold: float = 0.6     # min surrogate gate score to pass
+    shadow_eval_size: int = 10            # held-out tasks shown to the verifier
+    max_graduations_per_window: int = 2   # rate limit (used by the watch daemon)
+    surrogate_model: str | None = None    # defaults to harness.model
     lifecycle: LifecycleConfig = field(default_factory=LifecycleConfig)
 
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -10,6 +10,7 @@ _COMMAND_SPECS = {
     "eval": ("src.cli.commands.eval", "eval_cmd", "Evaluate the best skills on the validation set."),
     "harvest": ("src.cli.commands.harvest", "harvest_cmd", "Distill candidate skills from real usage traces."),
     "candidates": ("src.cli.commands.candidates", "candidates_cmd", "List/inspect harvested candidate skills."),
+    "library": ("src.cli.commands.library", "library_cmd", "Inspect/curate the skill library (stats, duplicates, retrieval)."),
     "skills": ("src.cli.commands.skills", "skills_cmd", "List all skills learned so far."),
     "diff": ("src.cli.commands.diff", "diff_cmd", "Diff baseline vs best, or between two specific iterations."),
     "logs": ("src.cli.commands.logs", "logs_cmd", "Show recent run history."),

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -8,6 +8,8 @@ _COMMAND_SPECS = {
     "init": ("src.cli.commands.init", "init_cmd", "Initialize a new EvoSkill project in the current directory."),
     "run": ("src.cli.commands.run", "run_cmd", "Run the self-improvement loop."),
     "eval": ("src.cli.commands.eval", "eval_cmd", "Evaluate the best skills on the validation set."),
+    "harvest": ("src.cli.commands.harvest", "harvest_cmd", "Distill candidate skills from real usage traces."),
+    "candidates": ("src.cli.commands.candidates", "candidates_cmd", "List/inspect harvested candidate skills."),
     "skills": ("src.cli.commands.skills", "skills_cmd", "List all skills learned so far."),
     "diff": ("src.cli.commands.diff", "diff_cmd", "Diff baseline vs best, or between two specific iterations."),
     "logs": ("src.cli.commands.logs", "logs_cmd", "Show recent run history."),

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -13,6 +13,7 @@ _COMMAND_SPECS = {
     "library": ("src.cli.commands.library", "library_cmd", "Inspect/curate the skill library (stats, duplicates, retrieval)."),
     "graduate": ("src.cli.commands.graduate", "graduate_cmd", "Gate and graduate a candidate skill into the library."),
     "reject": ("src.cli.commands.graduate", "reject_cmd", "Mark a candidate skill rejected."),
+    "watch": ("src.cli.commands.watch", "watch_cmd", "Run the continuous-evolution daemon (collect→distill→gate→graduate)."),
     "skills": ("src.cli.commands.skills", "skills_cmd", "List all skills learned so far."),
     "diff": ("src.cli.commands.diff", "diff_cmd", "Diff baseline vs best, or between two specific iterations."),
     "logs": ("src.cli.commands.logs", "logs_cmd", "Show recent run history."),

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -11,6 +11,8 @@ _COMMAND_SPECS = {
     "harvest": ("src.cli.commands.harvest", "harvest_cmd", "Distill candidate skills from real usage traces."),
     "candidates": ("src.cli.commands.candidates", "candidates_cmd", "List/inspect harvested candidate skills."),
     "library": ("src.cli.commands.library", "library_cmd", "Inspect/curate the skill library (stats, duplicates, retrieval)."),
+    "graduate": ("src.cli.commands.graduate", "graduate_cmd", "Gate and graduate a candidate skill into the library."),
+    "reject": ("src.cli.commands.graduate", "reject_cmd", "Mark a candidate skill rejected."),
     "skills": ("src.cli.commands.skills", "skills_cmd", "List all skills learned so far."),
     "diff": ("src.cli.commands.diff", "diff_cmd", "Diff baseline vs best, or between two specific iterations."),
     "logs": ("src.cli.commands.logs", "logs_cmd", "Show recent run history."),

--- a/src/continuous/__init__.py
+++ b/src/continuous/__init__.py
@@ -37,6 +37,7 @@ from .harvest import (
     HarvestResult,
     build_distiller_query,
     build_readers,
+    distill_clusters,
     harvest,
     slugify_skill_name,
 )
@@ -78,6 +79,14 @@ from .gate import (
     run_gate,
 )
 from .graduation import GraduationResult, graduate, install_skill
+from .loop import (
+    CostMeter,
+    MeteredAgent,
+    TickConfig,
+    TickReport,
+    run_tick,
+    run_watch_loop,
+)
 
 __all__ = [
     # episode model
@@ -112,6 +121,7 @@ __all__ = [
     "HarvestResult",
     "build_distiller_query",
     "build_readers",
+    "distill_clusters",
     "harvest",
     "slugify_skill_name",
     # library
@@ -154,4 +164,11 @@ __all__ = [
     "GraduationResult",
     "graduate",
     "install_skill",
+    # loop / watch tick
+    "CostMeter",
+    "MeteredAgent",
+    "TickConfig",
+    "TickReport",
+    "run_tick",
+    "run_watch_loop",
 ]

--- a/src/continuous/__init__.py
+++ b/src/continuous/__init__.py
@@ -40,6 +40,33 @@ from .harvest import (
     harvest,
     slugify_skill_name,
 )
+from .library import Skill, SkillLibrary, parse_skill_file
+from .similarity import (
+    EmbeddingCache,
+    EmbeddingSimilarity,
+    LexicalSimilarity,
+    SimilarityBackend,
+    make_openai_embedder,
+    make_similarity_backend,
+)
+from .skill_stats import (
+    SkillStats,
+    SkillStatsStore,
+    assign_credit,
+    assign_credit_batch,
+)
+from .lifecycle import (
+    DeprecationReport,
+    DuplicateGroup,
+    SkillMatch,
+    archive_skill,
+    build_merge_query,
+    evaluate_deprecation,
+    find_duplicates,
+    propose_merge,
+    restore_skill,
+    select_skills,
+)
 
 __all__ = [
     # episode model
@@ -76,4 +103,31 @@ __all__ = [
     "build_readers",
     "harvest",
     "slugify_skill_name",
+    # library
+    "Skill",
+    "SkillLibrary",
+    "parse_skill_file",
+    # similarity
+    "SimilarityBackend",
+    "LexicalSimilarity",
+    "EmbeddingSimilarity",
+    "EmbeddingCache",
+    "make_openai_embedder",
+    "make_similarity_backend",
+    # skill stats / credit
+    "SkillStats",
+    "SkillStatsStore",
+    "assign_credit",
+    "assign_credit_batch",
+    # lifecycle
+    "DuplicateGroup",
+    "SkillMatch",
+    "DeprecationReport",
+    "find_duplicates",
+    "select_skills",
+    "evaluate_deprecation",
+    "archive_skill",
+    "restore_skill",
+    "build_merge_query",
+    "propose_merge",
 ]

--- a/src/continuous/__init__.py
+++ b/src/continuous/__init__.py
@@ -1,0 +1,57 @@
+"""Continuous evolution: learn skills from real agent usage traces.
+
+Phase 0 surface — trace ingestion:
+
+* `TaskEpisode` / `ActionStep` / `ToolCall` — normalized usage unit.
+* `OutcomeSignal` / `Outcome` / `SignalKind` — how an attempt's success is judged.
+* Readers: `HarborTrajectoryReader` (primary, ATIF), `GooseRawReader` (fallback),
+  `JsonlReader` (generic).
+* `TraceCollector` + `TraceCursor` — dedup + watermark across continuous ticks.
+
+See `plan.md` for the full continuous-evolution design.
+"""
+
+from .episode import (
+    ActionStep,
+    Outcome,
+    OutcomeSignal,
+    SignalKind,
+    TaskEpisode,
+    ToolCall,
+)
+from .signals import clamp01, no_signal, signal_from_reward
+from .collector import (
+    GooseRawReader,
+    HarborTrajectoryReader,
+    JsonlReader,
+    TraceCollector,
+    TraceCursor,
+    TraceReader,
+    TraceReadError,
+    parse_atif_trajectory,
+    read_reward_file,
+)
+
+__all__ = [
+    # episode model
+    "ActionStep",
+    "Outcome",
+    "OutcomeSignal",
+    "SignalKind",
+    "TaskEpisode",
+    "ToolCall",
+    # signals
+    "clamp01",
+    "no_signal",
+    "signal_from_reward",
+    # collector
+    "GooseRawReader",
+    "HarborTrajectoryReader",
+    "JsonlReader",
+    "TraceCollector",
+    "TraceCursor",
+    "TraceReader",
+    "TraceReadError",
+    "parse_atif_trajectory",
+    "read_reward_file",
+]

--- a/src/continuous/__init__.py
+++ b/src/continuous/__init__.py
@@ -31,6 +31,15 @@ from .collector import (
     parse_atif_trajectory,
     read_reward_file,
 )
+from .cluster import EpisodeCluster, cluster_episodes
+from .candidates import Candidate, CandidateStore, make_candidate_id
+from .harvest import (
+    HarvestResult,
+    build_distiller_query,
+    build_readers,
+    harvest,
+    slugify_skill_name,
+)
 
 __all__ = [
     # episode model
@@ -54,4 +63,17 @@ __all__ = [
     "TraceReadError",
     "parse_atif_trajectory",
     "read_reward_file",
+    # clustering
+    "EpisodeCluster",
+    "cluster_episodes",
+    # candidates
+    "Candidate",
+    "CandidateStore",
+    "make_candidate_id",
+    # harvest
+    "HarvestResult",
+    "build_distiller_query",
+    "build_readers",
+    "harvest",
+    "slugify_skill_name",
 ]

--- a/src/continuous/__init__.py
+++ b/src/continuous/__init__.py
@@ -67,6 +67,17 @@ from .lifecycle import (
     restore_skill,
     select_skills,
 )
+from .gate import (
+    EvalOutcome,
+    GateEvaluator,
+    GateTask,
+    GateVerdict,
+    SurrogateEvaluator,
+    build_replay_buffer,
+    build_surrogate_query,
+    run_gate,
+)
+from .graduation import GraduationResult, graduate, install_skill
 
 __all__ = [
     # episode model
@@ -130,4 +141,17 @@ __all__ = [
     "restore_skill",
     "build_merge_query",
     "propose_merge",
+    # gate
+    "GateTask",
+    "GateVerdict",
+    "EvalOutcome",
+    "GateEvaluator",
+    "SurrogateEvaluator",
+    "build_replay_buffer",
+    "build_surrogate_query",
+    "run_gate",
+    # graduation
+    "GraduationResult",
+    "graduate",
+    "install_skill",
 ]

--- a/src/continuous/candidates.py
+++ b/src/continuous/candidates.py
@@ -1,0 +1,115 @@
+"""Candidate skill buffer.
+
+Distilled skills do NOT go straight into the live `.claude/skills/` library — they
+land here first, as *candidates* for review (and, in later phases, for the
+quality gate). This keeps the always-on learner safe: nothing reaches the agent
+the user actually runs until it has been gated/approved.
+
+Layout under `.evoskill/continuous/candidates/`:
+
+    <candidate_id>/
+        candidate.json   # metadata (pattern, provenance, status, stats)
+        SKILL.md         # the human-reviewable distilled skill
+
+`candidate_id` is derived from the skill name + a hash of the source episode ids,
+so re-harvesting the same cluster overwrites rather than duplicates.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+CandidateStatus = Literal["pending", "graduated", "rejected"]
+
+
+class Candidate(BaseModel):
+    """A distilled skill awaiting review/gating."""
+
+    candidate_id: str = Field(description="Stable id (skill_name + episode hash)")
+    skill_name: str = Field(description="kebab-case skill name")
+    skill_markdown: str = Field(description="Full SKILL.md content")
+    target_pattern: str = Field(default="", description="Recurring pattern addressed")
+    reasoning: str = Field(default="", description="Why it generalizes")
+
+    # Provenance.
+    source: str = Field(default="harvest", description="What produced this candidate")
+    cluster_key: str = Field(default="", description="Cluster label it was distilled from")
+    cluster_size: int = Field(default=0, description="Number of episodes in the cluster")
+    episode_ids: list[str] = Field(default_factory=list, description="Source episode ids")
+    outcome_focus: str = Field(default="failure", description="failure | success")
+
+    status: CandidateStatus = Field(default="pending", description="Lifecycle status")
+    model_name: str | None = Field(default=None, description="Distiller model")
+    created_at: str | None = Field(default=None, description="ISO timestamp")
+    extra: dict[str, Any] = Field(default_factory=dict)
+
+
+def make_candidate_id(skill_name: str, episode_ids: list[str]) -> str:
+    """Stable id: skill name + short hash of the (order-independent) episode set."""
+    digest = hashlib.sha256("|".join(sorted(episode_ids)).encode("utf-8")).hexdigest()[:8]
+    safe_name = skill_name.strip().lower() or "skill"
+    return f"{safe_name}-{digest}"
+
+
+class CandidateStore:
+    """Read/write the candidate buffer on disk."""
+
+    DEFAULT_SUBPATH = Path(".evoskill") / "continuous" / "candidates"
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+
+    def dir_for(self, candidate_id: str) -> Path:
+        return self.root / candidate_id
+
+    def save(self, candidate: Candidate, *, timestamp: str | None = None) -> Path:
+        """Persist a candidate (metadata + SKILL.md). Returns its directory."""
+        if candidate.created_at is None:
+            candidate = candidate.model_copy(
+                update={"created_at": timestamp or datetime.now().isoformat()}
+            )
+        target = self.dir_for(candidate.candidate_id)
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "candidate.json").write_text(candidate.model_dump_json(indent=2))
+        (target / "SKILL.md").write_text(candidate.skill_markdown)
+        return target
+
+    def get(self, candidate_id: str) -> Candidate | None:
+        meta = self.dir_for(candidate_id) / "candidate.json"
+        if not meta.is_file():
+            return None
+        try:
+            return Candidate.model_validate_json(meta.read_text())
+        except (OSError, ValueError):
+            return None
+
+    def list(self) -> list[Candidate]:
+        """All candidates, newest first (by created_at, then id)."""
+        if not self.root.is_dir():
+            return []
+        out: list[Candidate] = []
+        for child in self.root.iterdir():
+            if not child.is_dir():
+                continue
+            candidate = self.get(child.name)
+            if candidate is not None:
+                out.append(candidate)
+        out.sort(key=lambda c: (c.created_at or "", c.candidate_id), reverse=True)
+        return out
+
+    def set_status(self, candidate_id: str, status: CandidateStatus) -> Candidate | None:
+        """Update a candidate's lifecycle status in place."""
+        candidate = self.get(candidate_id)
+        if candidate is None:
+            return None
+        candidate = candidate.model_copy(update={"status": status})
+        # Preserve created_at (already set).
+        target = self.dir_for(candidate_id)
+        (target / "candidate.json").write_text(candidate.model_dump_json(indent=2))
+        return candidate

--- a/src/continuous/cluster.py
+++ b/src/continuous/cluster.py
@@ -1,0 +1,193 @@
+"""Cluster episodes by task similarity to surface recurring patterns.
+
+The harvest pipeline distills a skill from a *cluster* of episodes, not a single
+one — a skill earns its place by addressing a pattern that recurs, not a
+one-off. This module groups episodes (failures by default) so the distiller sees
+"here are 5 attempts that all struggled with the same kind of task."
+
+Implementation is deliberately dependency-free: a small TF-IDF vectorizer over
+each episode's task text + tool names, then greedy single-pass agglomerative
+clustering by cosine similarity. No numpy/sklearn — the corpus sizes continuous
+evolution targets (hundreds–low thousands of episodes per tick) are well within
+pure-Python reach, and avoiding a heavy embedding dependency keeps Phase 1
+self-contained. (Embedding-based similarity is a Phase 2 concern, for skill
+dedup, where the quality/ρ tradeoff is worth a dependency.)
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+from .episode import Outcome, TaskEpisode
+
+# Compact English stopword set — enough to stop common words from dominating the
+# TF-IDF space without pulling in a corpus dependency.
+_STOPWORDS = frozenset(
+    """
+    a an and are as at be by for from has have how i in into is it its of on or
+    that the their then there these this to was were what when where which who
+    will with you your do does did not but if can could should would may might
+    must shall this that's about above after again all also am any because been
+    before being below between both during each few more most other some such
+    only own same so than too very s t just don now
+    """.split()
+)
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercase word tokens, dropping stopwords and very short tokens."""
+    return [
+        tok
+        for tok in _TOKEN_RE.findall(text.lower())
+        if len(tok) >= 3 and tok not in _STOPWORDS
+    ]
+
+
+def _episode_tokens(episode: TaskEpisode) -> list[str]:
+    """Bag of tokens describing what an episode was about.
+
+    Combines the task text (what was asked) with the tool/function names the
+    agent used (how it approached it) — two episodes that asked similar things
+    *and* worked similarly are the strongest signal of a shared pattern.
+    """
+    tokens = _tokenize(episode.task_text)
+    for step in episode.actions:
+        for call in step.tool_calls:
+            if call.function_name:
+                tokens.append(call.function_name.lower())
+    return tokens
+
+
+@dataclass
+class EpisodeCluster:
+    """A group of similar episodes sharing an outcome focus."""
+
+    episodes: list[TaskEpisode]
+    outcome_focus: Outcome
+    top_terms: list[str] = field(default_factory=list)
+
+    @property
+    def size(self) -> int:
+        return len(self.episodes)
+
+    @property
+    def key(self) -> str:
+        """Short human-readable label from the cluster's top terms."""
+        return "-".join(self.top_terms[:4]) if self.top_terms else "cluster"
+
+    @property
+    def episode_ids(self) -> list[str]:
+        return [e.episode_id for e in self.episodes]
+
+    @property
+    def task_ids(self) -> list[str]:
+        return [e.task_id for e in self.episodes if e.task_id]
+
+
+def _cosine(a: dict[str, float], b: dict[str, float], a_norm: float, b_norm: float) -> float:
+    if a_norm == 0.0 or b_norm == 0.0:
+        return 0.0
+    # Iterate the smaller vector for the dot product.
+    if len(a) > len(b):
+        a, b = b, a
+    dot = sum(weight * b.get(term, 0.0) for term, weight in a.items())
+    return dot / (a_norm * b_norm)
+
+
+def _norm(vec: dict[str, float]) -> float:
+    return math.sqrt(sum(w * w for w in vec.values()))
+
+
+def cluster_episodes(
+    episodes: list[TaskEpisode],
+    *,
+    focus: Outcome = Outcome.FAILURE,
+    min_cluster_size: int = 3,
+    similarity_threshold: float = 0.3,
+    max_clusters: int | None = None,
+) -> list[EpisodeCluster]:
+    """Group `focus`-outcome episodes into similarity clusters.
+
+    Args:
+        episodes: all collected episodes (mixed outcomes).
+        focus: which outcome to cluster (FAILURE surfaces capability gaps;
+            SUCCESS surfaces reusable winning patterns).
+        min_cluster_size: drop clusters smaller than this — a pattern must recur.
+        similarity_threshold: cosine ≥ this joins an episode to a cluster.
+        max_clusters: keep only the largest N clusters (None = all).
+
+    Returns:
+        Clusters sorted by size (largest first). Empty if nothing qualifies.
+    """
+    pool = [e for e in episodes if e.outcome is focus]
+    if not pool:
+        return []
+
+    # ── document frequencies for IDF ──
+    docs_tokens = [_episode_tokens(e) for e in pool]
+    n_docs = len(pool)
+    df: Counter[str] = Counter()
+    for tokens in docs_tokens:
+        df.update(set(tokens))
+
+    def tfidf(tokens: list[str]) -> dict[str, float]:
+        if not tokens:
+            return {}
+        tf = Counter(tokens)
+        total = len(tokens)
+        vec: dict[str, float] = {}
+        for term, count in tf.items():
+            idf = math.log((1 + n_docs) / (1 + df[term])) + 1.0
+            vec[term] = (count / total) * idf
+        return vec
+
+    vectors = [tfidf(tokens) for tokens in docs_tokens]
+    norms = [_norm(v) for v in vectors]
+
+    # ── greedy single-pass clustering ──
+    # Each cluster keeps a centroid (summed member vectors) updated incrementally.
+    cluster_members: list[list[int]] = []
+    centroids: list[dict[str, float]] = []
+    centroid_norms: list[float] = []
+
+    for i in range(n_docs):
+        vec, vnorm = vectors[i], norms[i]
+        best_c, best_sim = -1, similarity_threshold
+        for c, centroid in enumerate(centroids):
+            sim = _cosine(vec, centroid, vnorm, centroid_norms[c])
+            if sim >= best_sim:
+                best_sim, best_c = sim, c
+        if best_c == -1:
+            cluster_members.append([i])
+            centroids.append(dict(vec))
+            centroid_norms.append(vnorm)
+        else:
+            cluster_members[best_c].append(i)
+            centroid = centroids[best_c]
+            for term, weight in vec.items():
+                centroid[term] = centroid.get(term, 0.0) + weight
+            centroid_norms[best_c] = _norm(centroid)
+
+    # ── build, filter, rank ──
+    clusters: list[EpisodeCluster] = []
+    for members, centroid in zip(cluster_members, centroids):
+        if len(members) < min_cluster_size:
+            continue
+        top_terms = [t for t, _ in sorted(centroid.items(), key=lambda kv: kv[1], reverse=True)[:6]]
+        clusters.append(
+            EpisodeCluster(
+                episodes=[pool[i] for i in members],
+                outcome_focus=focus,
+                top_terms=top_terms,
+            )
+        )
+
+    clusters.sort(key=lambda c: c.size, reverse=True)
+    if max_clusters is not None:
+        clusters = clusters[:max_clusters]
+    return clusters

--- a/src/continuous/collector.py
+++ b/src/continuous/collector.py
@@ -1,0 +1,672 @@
+"""Trace collection for continuous evolution.
+
+This module turns *raw agent traces on disk* into normalized `TaskEpisode`
+objects, deduplicated against a persistent watermark so each continuous tick
+only processes attempts it hasn't seen before.
+
+Readers (priority order — earlier wins on episode-id collisions):
+
+* `HarborTrajectoryReader` — **primary.** Parses the ATIF (Agent Trajectory
+  Interchange Format) `agent/trajectory.json` that every Harbor/Arena harness
+  emits (goose, opencode, codex, openhands, ...). Version-tolerant across the
+  ATIF schema versions observed in the wild (v1.2 … v1.6+). When a sibling
+  `verifier/reward.txt` exists, the reward becomes a ground-truth outcome signal.
+* `GooseRawReader` — **fallback.** Reconstructs an episode from the raw
+  token-streamed `agent/goose.txt` log, for the rare trial that has no ATIF
+  trajectory. Lower fidelity; only used when nothing better exists.
+* `JsonlReader` — **generic.** One JSON object per line following a small,
+  documented contract, for arbitrary integrations / hooks.
+
+The `TraceCollector` runs a list of readers, dedupes by `episode_id` (within the
+batch and against the `TraceCursor`), and optionally advances the watermark.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from .episode import ActionStep, Outcome, TaskEpisode, ToolCall
+from .signals import no_signal, signal_from_reward
+
+# Placeholder messages harnesses emit when a turn is purely a tool call; never a
+# real final answer.
+_TOOL_CALL_PLACEHOLDERS = {"[tool call]", "(tool use)", "[tool_call]", "(tool_use)", ""}
+
+
+class TraceReadError(RuntimeError):
+    """Raised when a single trace unit cannot be parsed into an episode."""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ATIF parsing helpers (shared, schema-version-tolerant)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _coerce_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _parse_tool_calls(step: dict[str, Any]) -> list[ToolCall]:
+    """Parse a step's `tool_calls`, linking each to its observation content.
+
+    ATIF stores observations separately as `observation.results[]`, linked back
+    to a call via `source_call_id` == `tool_call_id`. We fold the matching
+    observation content onto each ToolCall so a step is self-contained.
+    """
+    raw_calls = step.get("tool_calls") or []
+    if not isinstance(raw_calls, list):
+        return []
+
+    # Build call_id -> observation content map.
+    obs_by_id: dict[str, str] = {}
+    observation = step.get("observation") or {}
+    if isinstance(observation, dict):
+        for result in observation.get("results") or []:
+            if not isinstance(result, dict):
+                continue
+            call_id = result.get("source_call_id")
+            content = result.get("content")
+            if call_id is not None and content is not None:
+                obs_by_id[str(call_id)] = str(content)
+
+    calls: list[ToolCall] = []
+    for raw in raw_calls:
+        if not isinstance(raw, dict):
+            continue
+        call_id = raw.get("tool_call_id")
+        arguments = raw.get("arguments")
+        if not isinstance(arguments, dict):
+            arguments = {} if arguments is None else {"value": arguments}
+        calls.append(
+            ToolCall(
+                tool_call_id=str(call_id) if call_id is not None else None,
+                function_name=raw.get("function_name"),
+                arguments=arguments,
+                observation=obs_by_id.get(str(call_id)) if call_id is not None else None,
+            )
+        )
+    return calls
+
+
+def _parse_step(raw: dict[str, Any]) -> ActionStep:
+    return ActionStep(
+        step_id=raw.get("step_id"),
+        source=str(raw.get("source") or "agent"),
+        message=str(raw.get("message") or ""),
+        reasoning=str(raw.get("reasoning_content") or ""),
+        tool_calls=_parse_tool_calls(raw),
+    )
+
+
+def _derive_task_text(steps: list[dict[str, Any]]) -> str:
+    """Best-effort task text from the trace itself.
+
+    ATIF trajectories rarely embed the literal task prompt (it lives in the
+    task dataset), but the agent's first step almost always restates the goal in
+    its reasoning. We use the first step's reasoning, falling back to its message.
+    """
+    for step in steps:
+        reasoning = str(step.get("reasoning_content") or "").strip()
+        if reasoning:
+            return reasoning
+        message = str(step.get("message") or "").strip()
+        if message and message not in _TOOL_CALL_PLACEHOLDERS:
+            return message
+    return ""
+
+
+def _derive_final_output(steps: list[dict[str, Any]]) -> str:
+    """Best-effort final agent output: the last agent message with real content.
+
+    Note: for tasks graded on a file artifact, the true answer lives in the
+    environment, not the transcript — so this is a transcript-level proxy, and
+    the verifier reward (not this string) is the outcome of record.
+    """
+    for step in reversed(steps):
+        if str(step.get("source") or "agent") != "agent":
+            continue
+        message = str(step.get("message") or "").strip()
+        if message and message not in _TOOL_CALL_PLACEHOLDERS:
+            return message
+        # When the last turn is a bare tool call, the answer often sits in its
+        # reasoning — prefer that over an earlier step's intro message.
+        reasoning = str(step.get("reasoning_content") or "").strip()
+        if reasoning:
+            return reasoning
+    return ""
+
+
+def parse_atif_trajectory(
+    data: dict[str, Any],
+    *,
+    episode_id: str,
+    source: str = "harbor",
+    task_id: str | None = None,
+    raw_path: str | None = None,
+) -> TaskEpisode:
+    """Parse one ATIF `trajectory.json` payload into a `TaskEpisode`.
+
+    Tolerant of schema drift: only the common fields (`agent`, `steps`,
+    `final_metrics`) are read, and each is defaulted. Outcome is left UNKNOWN —
+    the caller attaches a signal (e.g. from a verifier reward) afterwards.
+    """
+    agent = data.get("agent") or {}
+    if not isinstance(agent, dict):
+        agent = {}
+    steps_raw = data.get("steps") or []
+    if not isinstance(steps_raw, list):
+        steps_raw = []
+    steps_raw = [s for s in steps_raw if isinstance(s, dict)]
+
+    metrics = data.get("final_metrics") or {}
+    if not isinstance(metrics, dict):
+        metrics = {}
+
+    # Timestamp: present per-step in v1.6, absent in v1.2.
+    timestamp = None
+    for step in reversed(steps_raw):
+        ts = step.get("timestamp")
+        if ts:
+            timestamp = str(ts)
+            break
+
+    return TaskEpisode(
+        episode_id=episode_id,
+        source=source,
+        task_id=task_id,
+        task_text=_derive_task_text(steps_raw),
+        actions=[_parse_step(s) for s in steps_raw],
+        final_output=_derive_final_output(steps_raw),
+        outcome=Outcome.UNKNOWN,
+        signal=None,
+        agent_name=agent.get("name"),
+        model_name=agent.get("model_name"),
+        prompt_tokens=_coerce_int(metrics.get("total_prompt_tokens")),
+        completion_tokens=_coerce_int(metrics.get("total_completion_tokens")),
+        cost_usd=_coerce_float(metrics.get("total_cost_usd")),
+        num_steps=_coerce_int(metrics.get("total_steps")) or len(steps_raw),
+        timestamp=timestamp,
+        raw_path=raw_path,
+        extra={
+            "schema_version": data.get("schema_version"),
+            "session_id": data.get("session_id"),
+        },
+    )
+
+
+def read_reward_file(trial_dir: Path) -> float | None:
+    """Read a Harbor verifier reward from `<trial>/verifier/reward.txt`.
+
+    Returns None when no parseable reward exists (unlabeled trial).
+    """
+    reward_path = trial_dir / "verifier" / "reward.txt"
+    if not reward_path.is_file():
+        return None
+    try:
+        text = reward_path.read_text().strip()
+    except OSError:
+        return None
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _read_result_task_id(trial_dir: Path) -> str | None:
+    """Pull the task id from a Harbor `result.json`, if present."""
+    result_path = trial_dir / "result.json"
+    if not result_path.is_file():
+        return None
+    try:
+        data = json.loads(result_path.read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    name = data.get("task_name") or data.get("source")
+    if name:
+        return str(name)
+    task_id = data.get("task_id")
+    if isinstance(task_id, dict) and task_id.get("path"):
+        return Path(str(task_id["path"])).name
+    return None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Readers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TraceReader(ABC):
+    """Base class for trace readers. Each yields normalized `TaskEpisode`s."""
+
+    #: Short source tag stamped onto every episode this reader produces.
+    source: str = "trace"
+
+    @abstractmethod
+    def read_all(self) -> Iterator[TaskEpisode]:
+        """Yield every episode this reader can recover, skipping unparseable units."""
+        raise NotImplementedError
+
+
+class HarborTrajectoryReader(TraceReader):
+    """Primary reader: ATIF `agent/trajectory.json` from Harbor/Arena trials.
+
+    Discovers every trial under `jobs_root` by locating `agent/trajectory.json`
+    files. For each, parses the ATIF payload, attaches a verifier-reward signal
+    when available, and resolves the task id from the sibling `result.json`.
+    """
+
+    source = "harbor"
+
+    def __init__(self, jobs_root: str | Path, *, success_threshold: float = 1.0) -> None:
+        self.jobs_root = Path(jobs_root).expanduser()
+        self.success_threshold = success_threshold
+
+    def _discover_trial_dirs(self) -> list[Path]:
+        """Trial dirs are the parents of `agent/trajectory.json`."""
+        if not self.jobs_root.is_dir():
+            return []
+        trials: list[Path] = []
+        for traj in self.jobs_root.rglob("trajectory.json"):
+            if traj.parent.name == "agent":
+                trials.append(traj.parent.parent)
+        # Stable order so collection / watermarking is reproducible.
+        trials.sort(key=lambda p: str(p))
+        return trials
+
+    def parse_trial(self, trial_dir: Path) -> TaskEpisode:
+        """Parse a single trial dir into an episode. Raises on unreadable JSON."""
+        traj_path = trial_dir / "agent" / "trajectory.json"
+        try:
+            data = json.loads(traj_path.read_text())
+        except (OSError, ValueError) as exc:
+            raise TraceReadError(f"unreadable trajectory {traj_path}: {exc}") from exc
+        if not isinstance(data, dict):
+            raise TraceReadError(f"trajectory is not a JSON object: {traj_path}")
+
+        episode_id = trial_dir.name or data.get("session_id") or _hash_path(traj_path)
+        episode = parse_atif_trajectory(
+            data,
+            episode_id=str(episode_id),
+            source=self.source,
+            task_id=_read_result_task_id(trial_dir),
+            raw_path=str(traj_path),
+        )
+
+        reward = read_reward_file(trial_dir)
+        if reward is not None:
+            episode.signal = signal_from_reward(reward, success_threshold=self.success_threshold)
+        else:
+            episode.signal = no_signal()
+        episode.outcome = episode.signal.outcome
+        return episode
+
+    def read_all(self) -> Iterator[TaskEpisode]:
+        for trial_dir in self._discover_trial_dirs():
+            try:
+                yield self.parse_trial(trial_dir)
+            except TraceReadError:
+                # A single corrupt trial must not abort the whole collection.
+                continue
+
+
+class GooseRawReader(TraceReader):
+    """Fallback reader: reconstruct an episode from raw `agent/goose.txt`.
+
+    `goose.txt` is a token-streamed JSONL log: each line carries a fragment of a
+    message (`thinking`/`text` deltas, tool requests). We group fragments by
+    message id and concatenate them into coarse `ActionStep`s. This is lossy and
+    only meant for trials lacking an ATIF trajectory; `HarborTrajectoryReader`
+    takes precedence when both exist (same `episode_id` ⇒ deduped).
+    """
+
+    source = "goose"
+
+    def __init__(self, jobs_root: str | Path, *, success_threshold: float = 1.0) -> None:
+        self.jobs_root = Path(jobs_root).expanduser()
+        self.success_threshold = success_threshold
+
+    def _discover_logs(self) -> list[Path]:
+        if not self.jobs_root.is_dir():
+            return []
+        logs = [p for p in self.jobs_root.rglob("goose.txt") if p.parent.name == "agent"]
+        logs.sort(key=lambda p: str(p))
+        return logs
+
+    def parse_log(self, log_path: Path) -> TaskEpisode:
+        trial_dir = log_path.parent.parent
+        try:
+            lines = log_path.read_text().splitlines()
+        except OSError as exc:
+            raise TraceReadError(f"unreadable goose log {log_path}: {exc}") from exc
+
+        # message id -> {"thinking": [...], "text": [...], "tools": [...]}
+        buffers: dict[str, dict[str, list]] = {}
+        order: list[str] = []
+        model_name: str | None = None
+
+        for line in lines:
+            line = line.strip()
+            if not line or not line.startswith("{"):
+                continue
+            try:
+                event = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(event, dict) or event.get("type") != "message":
+                continue
+            message = event.get("message") or {}
+            if not isinstance(message, dict):
+                continue
+            mid = str(message.get("id") or "")
+            if not mid:
+                continue
+            if mid not in buffers:
+                buffers[mid] = {"thinking": [], "text": [], "tools": []}
+                order.append(mid)
+            for chunk in message.get("content") or []:
+                if not isinstance(chunk, dict):
+                    continue
+                ctype = chunk.get("type")
+                if ctype == "thinking":
+                    buffers[mid]["thinking"].append(str(chunk.get("thinking") or ""))
+                elif ctype == "text":
+                    buffers[mid]["text"].append(str(chunk.get("text") or ""))
+                elif ctype in ("toolRequest", "tool_use", "toolUse"):
+                    buffers[mid]["tools"].append(chunk)
+
+        steps: list[ActionStep] = []
+        for i, mid in enumerate(order, start=1):
+            buf = buffers[mid]
+            tool_calls = [
+                ToolCall(
+                    tool_call_id=str(t.get("id")) if t.get("id") is not None else None,
+                    function_name=(t.get("toolCall") or {}).get("name")
+                    if isinstance(t.get("toolCall"), dict)
+                    else t.get("name"),
+                )
+                for t in buf["tools"]
+                if isinstance(t, dict)
+            ]
+            steps.append(
+                ActionStep(
+                    step_id=i,
+                    source="agent",
+                    message="".join(buf["text"]).strip(),
+                    reasoning="".join(buf["thinking"]).strip(),
+                    tool_calls=tool_calls,
+                )
+            )
+
+        if not steps:
+            raise TraceReadError(f"no reconstructable messages in {log_path}")
+
+        episode = TaskEpisode(
+            episode_id=trial_dir.name or _hash_path(log_path),
+            source=self.source,
+            task_id=_read_result_task_id(trial_dir),
+            task_text=steps[0].reasoning or steps[0].message,
+            actions=steps,
+            final_output=next(
+                (s.message for s in reversed(steps) if s.message), ""
+            ),
+            agent_name="goose",
+            model_name=model_name,
+            num_steps=len(steps),
+            raw_path=str(log_path),
+        )
+
+        reward = read_reward_file(trial_dir)
+        if reward is not None:
+            episode.signal = signal_from_reward(reward, success_threshold=self.success_threshold)
+        else:
+            episode.signal = no_signal()
+        episode.outcome = episode.signal.outcome
+        return episode
+
+    def read_all(self) -> Iterator[TaskEpisode]:
+        for log_path in self._discover_logs():
+            try:
+                yield self.parse_log(log_path)
+            except TraceReadError:
+                continue
+
+
+class JsonlReader(TraceReader):
+    """Generic reader: one JSON object per line.
+
+    Contract (all fields optional except `task`):
+
+        {
+          "episode_id": "...",          # stable id; derived from content if omitted
+          "task_id": "...",
+          "task": "the instruction",    # required
+          "output": "final answer",
+          "reward": 1.0,                # → ground-truth verifier-style signal
+          "outcome": "success",         # explicit override if no reward
+          "skills_active": ["s1"],
+          "agent": "claude-code",
+          "model": "...",
+          "steps": [{"source": "agent", "message": "...", "reasoning": "..."}]
+        }
+
+    Lines that are blank, non-JSON, or missing `task` are skipped.
+    """
+
+    source = "jsonl"
+
+    def __init__(
+        self, path: str | Path, *, source: str | None = None, success_threshold: float = 1.0
+    ) -> None:
+        self.path = Path(path).expanduser()
+        if source:
+            self.source = source
+        self.success_threshold = success_threshold
+
+    def parse_record(self, record: dict[str, Any], *, index: int) -> TaskEpisode:
+        task_text = str(record.get("task") or "").strip()
+        if not task_text:
+            raise TraceReadError(f"record {index} missing 'task'")
+
+        steps = []
+        for j, raw in enumerate(record.get("steps") or [], start=1):
+            if not isinstance(raw, dict):
+                continue
+            steps.append(
+                ActionStep(
+                    step_id=raw.get("step_id") or j,
+                    source=str(raw.get("source") or "agent"),
+                    message=str(raw.get("message") or ""),
+                    reasoning=str(raw.get("reasoning") or raw.get("reasoning_content") or ""),
+                )
+            )
+
+        episode_id = str(
+            record.get("episode_id")
+            or _hash_text(f"{self.path}:{index}:{task_text}")
+        )
+
+        episode = TaskEpisode(
+            episode_id=episode_id,
+            source=self.source,
+            task_id=record.get("task_id"),
+            task_text=task_text,
+            actions=steps,
+            final_output=str(record.get("output") or ""),
+            skills_active=[str(s) for s in (record.get("skills_active") or [])],
+            agent_name=record.get("agent"),
+            model_name=record.get("model"),
+            num_steps=len(steps),
+            raw_path=str(self.path),
+        )
+
+        reward = record.get("reward")
+        if reward is not None:
+            episode.signal = signal_from_reward(
+                _coerce_float(reward), success_threshold=self.success_threshold
+            )
+        elif record.get("outcome"):
+            outcome = _outcome_from_str(str(record["outcome"]))
+            episode.signal = no_signal(evidence=f"explicit outcome '{record['outcome']}'")
+            episode.signal.outcome = outcome
+            episode.signal.confidence = 0.5
+        else:
+            episode.signal = no_signal()
+        episode.outcome = episode.signal.outcome
+        return episode
+
+    def read_all(self) -> Iterator[TaskEpisode]:
+        if not self.path.is_file():
+            return
+        with self.path.open() as fh:
+            for index, line in enumerate(fh):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                try:
+                    yield self.parse_record(record, index=index)
+                except TraceReadError:
+                    continue
+
+
+def _outcome_from_str(value: str) -> Outcome:
+    v = value.strip().lower()
+    if v in ("success", "pass", "passed", "true", "1"):
+        return Outcome.SUCCESS
+    if v in ("failure", "fail", "failed", "false", "0"):
+        return Outcome.FAILURE
+    return Outcome.UNKNOWN
+
+
+def _hash_path(path: Path) -> str:
+    return _hash_text(str(path))
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Watermark cursor + collector
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TraceCursor:
+    """Persistent watermark of which episodes have already been collected.
+
+    Stored as JSON at `path` (default `.evoskill/continuous/cursor.json`). Keeps
+    a set of seen `episode_id`s so each tick only processes new attempts.
+
+    For the corpus sizes continuous evolution targets (hundreds–thousands of
+    episodes) a flat id set is fine; this can later be compacted to a per-source
+    timestamp watermark if the file grows large.
+    """
+
+    DEFAULT_PATH = Path(".evoskill") / "continuous" / "cursor.json"
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path) if path is not None else self.DEFAULT_PATH
+        self._seen: set[str] = set()
+        self.load()
+
+    def load(self) -> None:
+        if not self.path.is_file():
+            self._seen = set()
+            return
+        try:
+            data = json.loads(self.path.read_text())
+        except (OSError, ValueError):
+            self._seen = set()
+            return
+        seen = data.get("seen") if isinstance(data, dict) else None
+        self._seen = {str(x) for x in seen} if isinstance(seen, list) else set()
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"seen": sorted(self._seen), "count": len(self._seen)}
+        self.path.write_text(json.dumps(payload, indent=2))
+
+    def seen(self, episode_id: str) -> bool:
+        return episode_id in self._seen
+
+    def mark(self, episode_id: str) -> None:
+        self._seen.add(episode_id)
+
+    def __len__(self) -> int:
+        return len(self._seen)
+
+
+class TraceCollector:
+    """Run readers, normalize, dedup by `episode_id`, advance the watermark.
+
+    Reader order is priority: if two readers produce the same `episode_id`
+    (e.g. a trial with both an ATIF trajectory and a raw goose log), the earlier
+    reader wins and the later duplicate is dropped.
+    """
+
+    def __init__(
+        self,
+        readers: list[TraceReader],
+        *,
+        cursor: TraceCursor | None = None,
+    ) -> None:
+        self.readers = readers
+        self.cursor = cursor
+
+    def collect(self, *, advance: bool = True, limit: int | None = None) -> list[TaskEpisode]:
+        """Collect new episodes across all readers.
+
+        Args:
+            advance: mark collected episodes in the cursor and persist it.
+            limit: stop after this many *new* episodes (None = unlimited).
+
+        Returns:
+            New, deduplicated episodes in reader-priority then discovery order.
+        """
+        seen_in_batch: set[str] = set()
+        episodes: list[TaskEpisode] = []
+
+        for reader in self.readers:
+            for episode in reader.read_all():
+                eid = episode.episode_id
+                if eid in seen_in_batch:
+                    continue
+                if self.cursor is not None and self.cursor.seen(eid):
+                    continue
+                seen_in_batch.add(eid)
+                episodes.append(episode)
+                if limit is not None and len(episodes) >= limit:
+                    break
+            if limit is not None and len(episodes) >= limit:
+                break
+
+        if advance and self.cursor is not None:
+            for episode in episodes:
+                self.cursor.mark(episode.episode_id)
+            self.cursor.save()
+
+        return episodes

--- a/src/continuous/episode.py
+++ b/src/continuous/episode.py
@@ -1,0 +1,140 @@
+"""Core data model for continuous evolution.
+
+Continuous evolution learns from *real agent usage* rather than from a fixed
+labeled benchmark. The unit of usage is a `TaskEpisode`: one attempt by some
+agent at some task, with whatever step-by-step detail and outcome signal we
+could recover from its trace.
+
+Readers in `collector.py` normalize harness-specific trace formats (Harbor's
+ATIF `trajectory.json`, raw goose/opencode logs, generic JSONL) into this one
+shape, so every downstream stage (clustering, distillation, gating) is
+harness-agnostic.
+
+These models are intentionally permissive: traces in the wild are messy and
+schema versions drift (e.g. Harbor's ATIF v1.2 vs v1.6), so every field other
+than `episode_id` and `source` has a safe default. Validation should never be
+the reason a usable episode is dropped.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class Outcome(str, Enum):
+    """Whether a task attempt succeeded, judged by an `OutcomeSignal`."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    UNKNOWN = "unknown"
+
+
+class SignalKind(str, Enum):
+    """Where an outcome judgement came from.
+
+    `VERIFIER_REWARD` is the only signal produced in Phase 0 — it reads a
+    ground-truth reward from a Harbor verifier. The remaining kinds are the
+    implicit/surrogate signals planned for the unlabeled production case
+    (Phase 5 / Phase 3) and are defined here so the enum is stable across
+    phases.
+    """
+
+    VERIFIER_REWARD = "verifier_reward"
+    TESTS_PASSED = "tests_passed"
+    DIFF_COMMITTED = "diff_committed"
+    CI_GREEN = "ci_green"
+    USER_ACCEPTED = "user_accepted"
+    USER_THUMBS = "user_thumbs"
+    NO_RETRY = "no_retry"
+    SURROGATE_VERIFIED = "surrogate_verified"
+    NONE = "none"
+
+
+class OutcomeSignal(BaseModel):
+    """How an episode's outcome was determined, with a confidence.
+
+    `value` is the normalized strength of the signal in [0, 1] (e.g. a raw
+    verifier reward), while `outcome` is the discrete judgement derived from it.
+    `confidence` lets downstream gating weight a ground-truth verifier (1.0)
+    above a noisy implicit signal (e.g. 0.5 for "the agent didn't retry").
+    """
+
+    kind: SignalKind = Field(description="Which extractor produced this signal")
+    outcome: Outcome = Field(description="Discrete success/failure/unknown judgement")
+    value: float = Field(default=0.0, description="Normalized signal strength in [0, 1]")
+    confidence: float = Field(default=1.0, description="Trust in this signal in [0, 1]")
+    evidence: str = Field(default="", description="Human-readable reason for the judgement")
+
+
+class ToolCall(BaseModel):
+    """A single tool invocation within a step, with its observation if known.
+
+    `observation` is the tool's result, linked back from the step's observation
+    block via the matching call id. It may be absent when a trace records the
+    call but not (yet) its result.
+    """
+
+    tool_call_id: str | None = Field(default=None, description="Provider call id")
+    function_name: str | None = Field(default=None, description="Tool/function name")
+    arguments: dict[str, Any] = Field(default_factory=dict, description="Call arguments")
+    observation: str | None = Field(default=None, description="Tool result content")
+
+
+class ActionStep(BaseModel):
+    """One step of an episode: a message, reasoning, and/or tool calls.
+
+    Mirrors a single entry in an ATIF `steps[]` array but is not tied to any
+    schema version. `source` is preserved verbatim ("agent", "user", "tool",
+    "system", "environment", ...) so we never assume every step is the agent.
+    """
+
+    step_id: int | None = Field(default=None, description="Ordinal step id")
+    source: str = Field(default="agent", description="Who produced this step")
+    message: str = Field(default="", description="Visible message text")
+    reasoning: str = Field(default="", description="Hidden/thinking content")
+    tool_calls: list[ToolCall] = Field(default_factory=list, description="Tool calls in this step")
+
+
+class TaskEpisode(BaseModel):
+    """One agent attempt at one task, normalized across harnesses.
+
+    This is the atomic unit continuous evolution consumes. `episode_id` must be
+    stable and unique per attempt so the watermark cursor can dedup across ticks.
+    """
+
+    episode_id: str = Field(description="Stable unique id for this attempt")
+    source: str = Field(description="Reader that produced it: harbor | goose | jsonl | claude_code")
+
+    task_id: str | None = Field(default=None, description="Task identifier, if known")
+    task_text: str = Field(default="", description="The task/instruction the agent worked on")
+    actions: list[ActionStep] = Field(default_factory=list, description="Step-by-step trace")
+    final_output: str = Field(default="", description="Agent's final textual output, best-effort")
+
+    outcome: Outcome = Field(default=Outcome.UNKNOWN, description="Resolved outcome")
+    signal: OutcomeSignal | None = Field(default=None, description="How the outcome was judged")
+
+    skills_active: list[str] = Field(
+        default_factory=list, description="Names of live skills loaded during the attempt"
+    )
+
+    # Provenance / metrics — useful for credit assignment, cost ceilings, and analysis.
+    agent_name: str | None = Field(default=None, description="Harness/agent name")
+    model_name: str | None = Field(default=None, description="Model identifier")
+    prompt_tokens: int = Field(default=0, description="Total prompt tokens")
+    completion_tokens: int = Field(default=0, description="Total completion tokens")
+    cost_usd: float = Field(default=0.0, description="Total cost in USD if reported")
+    num_steps: int = Field(default=0, description="Number of steps in the trace")
+    timestamp: str | None = Field(default=None, description="When the attempt ran, if known")
+    raw_path: str | None = Field(default=None, description="Source path, for provenance")
+    extra: dict[str, Any] = Field(default_factory=dict, description="Reader-specific extras")
+
+    @property
+    def is_success(self) -> bool:
+        return self.outcome is Outcome.SUCCESS
+
+    @property
+    def is_failure(self) -> bool:
+        return self.outcome is Outcome.FAILURE

--- a/src/continuous/gate.py
+++ b/src/continuous/gate.py
@@ -1,0 +1,165 @@
+"""The quality gate: judge a candidate before it can graduate.
+
+The gate enforces the one invariant continuous evolution cannot live without:
+**a candidate never goes live on the strength of the episodes that created it.**
+It is judged on a held-out *replay buffer* — episodes the candidate was not
+distilled from — exactly as the batch loop scores on a validation set it never
+proposed against.
+
+Phase 3 ships the **surrogate verifier** evaluator (research direction A): an
+isolated verifier agent synthesizes assertions from the candidate skill and the
+held-out task descriptions and decides whether the skill is correct and
+generalizable — no ground truth, no re-running the agent. The `GateEvaluator`
+interface lets a shadow-re-eval evaluator drop in later without touching the
+policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from .candidates import Candidate
+from .episode import TaskEpisode
+from .signals import clamp01
+
+
+@dataclass
+class GateTask:
+    """A held-out task shown to the evaluator — description only, no answer."""
+
+    task_text: str
+    task_id: str | None = None
+
+
+@dataclass
+class EvalOutcome:
+    """An evaluator's judgement of a candidate."""
+
+    score: float
+    verdict: bool
+    assertions: list[str] = field(default_factory=list)
+    detail: str = ""
+
+
+@dataclass
+class GateVerdict:
+    """The gate's decision for one candidate."""
+
+    passed: bool
+    method: str
+    score: float
+    threshold: float
+    n_tasks: int
+    assertions: list[str] = field(default_factory=list)
+    detail: str = ""
+
+
+def build_replay_buffer(
+    episodes: list[TaskEpisode],
+    candidate: Candidate,
+    *,
+    size: int = 10,
+) -> list[TaskEpisode]:
+    """Held-out episodes for judging `candidate`.
+
+    Excludes every episode the candidate was distilled from (`candidate.episode_ids`)
+    so the gate measures generalization, not recall. Deterministic: returns the
+    first `size` remaining episodes in their given order.
+    """
+    excluded = set(candidate.episode_ids)
+    held_out = [e for e in episodes if e.episode_id not in excluded]
+    return held_out[:size]
+
+
+class GateEvaluator(Protocol):
+    """Judges a candidate against held-out tasks. `method` names the strategy."""
+
+    method: str
+
+    async def evaluate(self, candidate: Candidate, tasks: list[GateTask]) -> EvalOutcome:  # pragma: no cover - protocol
+        ...
+
+
+def build_surrogate_query(
+    candidate: Candidate,
+    tasks: list[GateTask],
+    *,
+    max_tasks: int = 10,
+    task_chars: int = 400,
+) -> str:
+    """Render the candidate + held-out tasks into a prompt for the verifier."""
+    lines = [
+        "## Candidate skill (SKILL.md)",
+        candidate.skill_markdown.strip(),
+        "",
+        "## Held-out task descriptions (the skill was NOT distilled from these)",
+    ]
+    shown = tasks[:max_tasks]
+    if not shown:
+        lines.append("(none available — judge the skill on its own merits)")
+    for i, t in enumerate(shown, start=1):
+        text = t.task_text.strip()
+        if len(text) > task_chars:
+            text = text[: task_chars - 1].rstrip() + "…"
+        lines.append(f"{i}. {text or '(no description)'}")
+    if len(tasks) > max_tasks:
+        lines.append(f"(+{len(tasks) - max_tasks} more not shown)")
+    lines += [
+        "",
+        "Synthesize assertions, then decide whether this skill is correct and "
+        "generalizable (not memorized). Return score, verdict, assertions, reasoning.",
+    ]
+    return "\n".join(lines)
+
+
+class SurrogateEvaluator:
+    """Judge a candidate with an isolated surrogate-verifier agent."""
+
+    method = "surrogate"
+
+    def __init__(self, verifier: Any, *, max_tasks: int = 10) -> None:
+        self._verifier = verifier
+        self.max_tasks = max_tasks
+
+    async def evaluate(self, candidate: Candidate, tasks: list[GateTask]) -> EvalOutcome:
+        query = build_surrogate_query(candidate, tasks, max_tasks=self.max_tasks)
+        try:
+            trace = await self._verifier.run(query)
+        except Exception as exc:  # noqa: BLE001 - a verifier failure must not crash the gate
+            return EvalOutcome(score=0.0, verdict=False, detail=f"verifier error: {exc}")
+        output = getattr(trace, "output", None)
+        if output is None:
+            return EvalOutcome(score=0.0, verdict=False, detail="verifier produced no output")
+        return EvalOutcome(
+            score=clamp01(float(getattr(output, "score", 0.0) or 0.0)),
+            verdict=bool(getattr(output, "verdict", False)),
+            assertions=list(getattr(output, "assertions", []) or []),
+            detail=str(getattr(output, "reasoning", "") or ""),
+        )
+
+
+async def run_gate(
+    candidate: Candidate,
+    replay_episodes: list[TaskEpisode],
+    evaluator: GateEvaluator,
+    *,
+    threshold: float = 0.6,
+) -> GateVerdict:
+    """Run the gate: evaluate the candidate on the held-out buffer, apply the policy.
+
+    A candidate passes only if the evaluator returns `verdict=True` AND its score
+    meets `threshold`. Both conditions guard against weak passes.
+    """
+    tasks = [GateTask(task_text=e.task_text, task_id=e.task_id) for e in replay_episodes]
+    outcome = await evaluator.evaluate(candidate, tasks)
+    passed = bool(outcome.verdict) and outcome.score >= threshold
+    return GateVerdict(
+        passed=passed,
+        method=evaluator.method,
+        score=outcome.score,
+        threshold=threshold,
+        n_tasks=len(tasks),
+        assertions=outcome.assertions,
+        detail=outcome.detail,
+    )

--- a/src/continuous/graduation.py
+++ b/src/continuous/graduation.py
@@ -1,0 +1,115 @@
+"""Graduate a passing candidate into the live skill library.
+
+Graduation is the only step that changes the live library, so it is deliberate
+and auditable:
+
+1. Install the candidate's `SKILL.md` into `.claude/skills/<name>/`.
+2. For a *merge* candidate, archive the originals it replaces (reversibly).
+3. If a `ProgramManager` is supplied, snapshot the change as a `program/*` git
+   branch — so every graduation is versioned and revertible, exactly like the
+   batch loop's programs. (Branched from the current HEAD; it does NOT join the
+   accuracy-based frontier, so continuous graduations never pollute the main
+   loop's score ranking.)
+4. Mark the candidate `graduated` in the buffer.
+
+The `ProgramManager` is injected so the filesystem behaviour is unit-testable
+without git, while a real-repo integration test exercises the branch path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .candidates import Candidate, CandidateStore
+from .lifecycle import archive_skill
+
+
+def install_skill(skills_dir: str | Path, skill_name: str, skill_markdown: str) -> Path:
+    """Write a skill into the live library at `<skills_dir>/<name>/SKILL.md`."""
+    target = Path(skills_dir) / skill_name
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "SKILL.md").write_text(skill_markdown)
+    return target
+
+
+@dataclass
+class GraduationResult:
+    candidate_id: str
+    skill_name: str
+    installed_path: str
+    branch: str | None = None
+    archived_originals: list[str] = field(default_factory=list)
+
+
+def _archive_merge_originals(
+    candidate: Candidate, skills_dir: Path, archive_dir: str | Path | None
+) -> list[str]:
+    """For a merge candidate, archive the skills it supersedes. Best-effort."""
+    if candidate.source != "merge" or archive_dir is None:
+        return []
+    archived: list[str] = []
+    for original in candidate.extra.get("merged_from", []) or []:
+        if original == candidate.skill_name:
+            continue  # never archive the freshly-installed merged skill
+        try:
+            archive_skill(skills_dir, original, archive_dir)
+            archived.append(original)
+        except FileNotFoundError:
+            continue
+    return archived
+
+
+def graduate(
+    candidate: Candidate,
+    *,
+    skills_dir: str | Path,
+    store: CandidateStore,
+    manager: Any | None = None,
+    archive_dir: str | Path | None = None,
+    branch_prefix: str = "iter-skill",
+    gate_score: float | None = None,
+) -> GraduationResult:
+    """Install a candidate skill and (optionally) version it as a `program/*` branch.
+
+    Args:
+        candidate: the candidate to graduate.
+        skills_dir: the live `.claude/skills/` directory.
+        store: candidate buffer (its status is set to "graduated").
+        manager: a ProgramManager-like object; if given, the change is committed
+            to a new `program/*` branch (branched from current HEAD).
+        archive_dir: where merge-superseded skills are archived (reversible).
+        gate_score: the gate score, recorded in branch metadata for audit.
+
+    Returns:
+        GraduationResult describing what was installed/archived/branched.
+    """
+    skills_dir = Path(skills_dir)
+    installed = install_skill(skills_dir, candidate.skill_name, candidate.skill_markdown)
+    archived = _archive_merge_originals(candidate, skills_dir, archive_dir)
+
+    branch: str | None = None
+    if manager is not None:
+        branch_name = f"{branch_prefix}-{candidate.candidate_id}"
+        config = manager.get_current().mutate(
+            name=branch_name,
+            metadata={
+                "graduated_from": candidate.candidate_id,
+                "source": candidate.source,
+                "gate_score": gate_score,
+                "continuous": True,
+            },
+        )
+        # parent=None → branch from current HEAD; the installed (untracked) skill
+        # is carried onto the new branch and committed by create_program.
+        branch = manager.create_program(branch_name, config, parent=None)
+
+    store.set_status(candidate.candidate_id, "graduated")
+    return GraduationResult(
+        candidate_id=candidate.candidate_id,
+        skill_name=candidate.skill_name,
+        installed_path=str(installed),
+        branch=branch,
+        archived_originals=archived,
+    )

--- a/src/continuous/harvest.py
+++ b/src/continuous/harvest.py
@@ -123,10 +123,67 @@ class HarvestResult:
     candidates: list[Candidate]
     failed_distillations: int = 0
     skipped_clusters: int = field(default=0)
+    cost_usd: float = 0.0
 
     @property
     def num_candidates(self) -> int:
         return len(self.candidates)
+
+
+async def distill_clusters(
+    clusters: list[EpisodeCluster],
+    distiller: DistillerLike,
+    store: CandidateStore,
+    *,
+    source: str = "harvest",
+    concurrency: int = 4,
+    log: _Logger | None = None,
+) -> tuple[list[Candidate], int, float]:
+    """Distill one candidate per cluster and persist them.
+
+    Shared by the offline `harvest()` and the `watch` daemon's tick so both use
+    one distillation path. Returns (candidates, failed_count, total_cost_usd).
+    A cluster whose distillation errors or yields no usable skill is counted as
+    failed (never aborts the batch).
+    """
+    emit = log or (lambda _msg: None)
+    if not clusters:
+        return [], 0, 0.0
+
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+
+    async def _distill(cluster: EpisodeCluster) -> tuple[Candidate | None, float]:
+        async with semaphore:
+            query = build_distiller_query(cluster)
+            try:
+                trace = await distiller.run(query)
+            except Exception as exc:  # noqa: BLE001 - one bad cluster shouldn't abort the batch
+                emit(f"  [warn] distillation failed for cluster '{cluster.key}': {exc}")
+                return None, 0.0
+            cost = float(getattr(trace, "total_cost_usd", 0.0) or 0.0)
+            candidate = _candidate_from_output(
+                getattr(trace, "output", None), cluster,
+                source=source, model_name=getattr(trace, "model", None),
+            )
+            if candidate is None:
+                emit(f"  [warn] distiller produced no usable skill for '{cluster.key}'")
+            return candidate, cost
+
+    results = await asyncio.gather(*[_distill(c) for c in clusters])
+
+    candidates: list[Candidate] = []
+    failed = 0
+    total_cost = 0.0
+    for candidate, cost in results:
+        total_cost += cost
+        if candidate is None:
+            failed += 1
+            continue
+        store.save(candidate)
+        candidates.append(candidate)
+        emit(f"  + candidate '{candidate.skill_name}' "
+             f"(from {candidate.cluster_size} episodes) → {candidate.candidate_id}")
+    return candidates, failed, total_cost
 
 
 def _candidate_from_output(
@@ -213,41 +270,14 @@ async def harvest(
     if not clusters:
         return HarvestResult(episodes_collected=len(episodes), clusters=[], candidates=[])
 
-    semaphore = asyncio.Semaphore(max(1, concurrency))
-
-    async def _distill(cluster: EpisodeCluster) -> Candidate | None:
-        async with semaphore:
-            query = build_distiller_query(cluster)
-            try:
-                trace = await distiller.run(query)
-            except Exception as exc:  # noqa: BLE001 - one bad cluster shouldn't abort harvest
-                emit(f"  [warn] distillation failed for cluster '{cluster.key}': {exc}")
-                return None
-            output = getattr(trace, "output", None)
-            model_name = getattr(trace, "model", None)
-            candidate = _candidate_from_output(
-                output, cluster, source=source, model_name=model_name
-            )
-            if candidate is None:
-                emit(f"  [warn] distiller produced no usable skill for '{cluster.key}'")
-            return candidate
-
-    results = await asyncio.gather(*[_distill(c) for c in clusters])
-
-    candidates: list[Candidate] = []
-    failed = 0
-    for candidate in results:
-        if candidate is None:
-            failed += 1
-            continue
-        store.save(candidate)
-        candidates.append(candidate)
-        emit(f"  + candidate '{candidate.skill_name}' "
-             f"(from {candidate.cluster_size} episodes) → {candidate.candidate_id}")
+    candidates, failed, cost = await distill_clusters(
+        clusters, distiller, store, source=source, concurrency=concurrency, log=emit,
+    )
 
     return HarvestResult(
         episodes_collected=len(episodes),
         clusters=clusters,
         candidates=candidates,
         failed_distillations=failed,
+        cost_usd=cost,
     )

--- a/src/continuous/harvest.py
+++ b/src/continuous/harvest.py
@@ -1,0 +1,253 @@
+"""Offline harvest: turn a window of real episodes into candidate skills.
+
+This is the Phase 1 pipeline — steps 1, 2, 4, 5 of the continuous loop
+(COLLECT → SIGNAL → CLUSTER → DISTILL), without the always-on daemon or the
+quality gate. Credit assignment (step 3) and gating/graduation (steps 6–8) are
+later phases; harvest only *proposes* candidates into the review buffer.
+
+`harvest()` takes its collaborators (readers, distiller, store) as arguments so
+it is fully testable without a real LLM or CLI: tests inject a fake distiller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol
+
+from .candidates import Candidate, CandidateStore, make_candidate_id
+from .cluster import EpisodeCluster, cluster_episodes
+from .collector import (
+    GooseRawReader,
+    HarborTrajectoryReader,
+    JsonlReader,
+    TraceCollector,
+    TraceCursor,
+    TraceReader,
+)
+from .episode import Outcome, TaskEpisode
+
+_Logger = Callable[[str], None]
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+class DistillerLike(Protocol):
+    """Anything with an async `run(query) -> trace` whose `.output` is a
+    SkillDistillerResponse (or None on parse failure). `src.harness.Agent`
+    satisfies this; tests provide a fake."""
+
+    async def run(self, query: str) -> Any:  # pragma: no cover - protocol
+        ...
+
+
+def build_readers(
+    sources: list[str],
+    *,
+    traces_root: str | None = None,
+    jsonl_path: str | None = None,
+    success_threshold: float = 1.0,
+) -> list[TraceReader]:
+    """Construct trace readers for the requested sources, in priority order.
+
+    Unknown source names and sources missing their path are skipped, so a
+    partially-configured project still harvests from whatever is available.
+    """
+    readers: list[TraceReader] = []
+    for source in sources:
+        if source == "harbor" and traces_root:
+            readers.append(HarborTrajectoryReader(traces_root, success_threshold=success_threshold))
+        elif source == "goose" and traces_root:
+            readers.append(GooseRawReader(traces_root, success_threshold=success_threshold))
+        elif source == "jsonl" and jsonl_path:
+            readers.append(JsonlReader(jsonl_path, success_threshold=success_threshold))
+    return readers
+
+
+def slugify_skill_name(name: str, *, fallback: str = "distilled-skill") -> str:
+    """Normalize a skill name to a safe kebab-case directory/frontmatter name."""
+    slug = _SLUG_RE.sub("-", name.strip().lower()).strip("-")
+    return slug or fallback
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = text.strip()
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def build_distiller_query(
+    cluster: EpisodeCluster,
+    *,
+    max_examples: int = 6,
+    task_chars: int = 600,
+    output_chars: int = 300,
+) -> str:
+    """Render a cluster into a prompt for the distiller.
+
+    Summarizes the shared pattern and a handful of example episodes — what was
+    asked, which tools the agent used, and its final output — so the distiller
+    can find the transferable lesson without seeing every raw trace.
+    """
+    focus = cluster.outcome_focus.value
+    lines: list[str] = [
+        f"You are given {cluster.size} episodes that share an outcome of "
+        f"'{focus}' and were clustered together by task similarity.",
+        f"Common terms across the cluster: {', '.join(cluster.top_terms) or '(none)'}.",
+        "",
+        "Distill ONE reusable, generalizable skill that would help an agent handle "
+        f"this kind of task. Do not memorize specifics from these examples.",
+        "",
+        "## Example episodes",
+    ]
+    for i, ep in enumerate(cluster.episodes[:max_examples], start=1):
+        tools = sorted(
+            {c.function_name for s in ep.actions for c in s.tool_calls if c.function_name}
+        )
+        lines.append(f"\n### Episode {i} (outcome: {ep.outcome.value})")
+        lines.append(f"Task: {_truncate(ep.task_text, task_chars) or '(unknown)'}")
+        if tools:
+            lines.append(f"Tools used: {', '.join(tools)}")
+        if ep.final_output:
+            lines.append(f"Final output: {_truncate(ep.final_output, output_chars)}")
+    if cluster.size > max_examples:
+        lines.append(f"\n(+{cluster.size - max_examples} more similar episodes not shown)")
+    return "\n".join(lines)
+
+
+@dataclass
+class HarvestResult:
+    """Outcome of one harvest run."""
+
+    episodes_collected: int
+    clusters: list[EpisodeCluster]
+    candidates: list[Candidate]
+    failed_distillations: int = 0
+    skipped_clusters: int = field(default=0)
+
+    @property
+    def num_candidates(self) -> int:
+        return len(self.candidates)
+
+
+def _candidate_from_output(
+    output: Any,
+    cluster: EpisodeCluster,
+    *,
+    source: str,
+    model_name: str | None,
+) -> Candidate | None:
+    """Build a Candidate from a SkillDistillerResponse-like object, or None."""
+    candidate_skill = getattr(output, "candidate_skill", None)
+    if not candidate_skill or not str(candidate_skill).strip():
+        return None
+    raw_name = getattr(output, "skill_name", "") or cluster.key
+    skill_name = slugify_skill_name(str(raw_name))
+    episode_ids = cluster.episode_ids
+    return Candidate(
+        candidate_id=make_candidate_id(skill_name, episode_ids),
+        skill_name=skill_name,
+        skill_markdown=str(candidate_skill),
+        target_pattern=str(getattr(output, "target_pattern", "") or ""),
+        reasoning=str(getattr(output, "reasoning", "") or ""),
+        source=source,
+        cluster_key=cluster.key,
+        cluster_size=cluster.size,
+        episode_ids=episode_ids,
+        outcome_focus=cluster.outcome_focus.value,
+        model_name=model_name,
+    )
+
+
+async def harvest(
+    *,
+    readers: list[TraceReader],
+    distiller: DistillerLike,
+    store: CandidateStore,
+    cursor: TraceCursor | None = None,
+    window: int = 200,
+    min_cluster_size: int = 3,
+    similarity_threshold: float = 0.3,
+    focus: Outcome = Outcome.FAILURE,
+    max_candidates: int | None = None,
+    concurrency: int = 4,
+    advance_cursor: bool = False,
+    source: str = "harvest",
+    log: _Logger | None = None,
+) -> HarvestResult:
+    """Run the offline harvest pipeline and write candidates to the store.
+
+    Args:
+        readers: trace readers to collect episodes from.
+        distiller: agent that turns a cluster prompt into a candidate skill.
+        store: candidate buffer to write into.
+        cursor: optional watermark. `advance_cursor=False` (default) means harvest
+            does NOT consume the watermark — it is a manual review tool the user
+            can re-run; the `watch` daemon is what advances it.
+        window: max new episodes to collect.
+        min_cluster_size / similarity_threshold: clustering parameters.
+        focus: which outcome to mine (FAILURE = capability gaps).
+        max_candidates: cap clusters distilled (largest first).
+        concurrency: parallel distiller calls.
+        source: provenance tag stored on candidates.
+        log: optional progress callback.
+
+    Returns:
+        HarvestResult with collected/clustered/candidate counts.
+    """
+    emit = log or (lambda _msg: None)
+
+    collector = TraceCollector(readers, cursor=cursor)
+    episodes = collector.collect(advance=advance_cursor, limit=window)
+    emit(f"Collected {len(episodes)} episode(s).")
+
+    clusters = cluster_episodes(
+        episodes,
+        focus=focus,
+        min_cluster_size=min_cluster_size,
+        similarity_threshold=similarity_threshold,
+        max_clusters=max_candidates,
+    )
+    emit(f"Found {len(clusters)} cluster(s) of '{focus.value}' episodes "
+         f"(min size {min_cluster_size}).")
+
+    if not clusters:
+        return HarvestResult(episodes_collected=len(episodes), clusters=[], candidates=[])
+
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+
+    async def _distill(cluster: EpisodeCluster) -> Candidate | None:
+        async with semaphore:
+            query = build_distiller_query(cluster)
+            try:
+                trace = await distiller.run(query)
+            except Exception as exc:  # noqa: BLE001 - one bad cluster shouldn't abort harvest
+                emit(f"  [warn] distillation failed for cluster '{cluster.key}': {exc}")
+                return None
+            output = getattr(trace, "output", None)
+            model_name = getattr(trace, "model", None)
+            candidate = _candidate_from_output(
+                output, cluster, source=source, model_name=model_name
+            )
+            if candidate is None:
+                emit(f"  [warn] distiller produced no usable skill for '{cluster.key}'")
+            return candidate
+
+    results = await asyncio.gather(*[_distill(c) for c in clusters])
+
+    candidates: list[Candidate] = []
+    failed = 0
+    for candidate in results:
+        if candidate is None:
+            failed += 1
+            continue
+        store.save(candidate)
+        candidates.append(candidate)
+        emit(f"  + candidate '{candidate.skill_name}' "
+             f"(from {candidate.cluster_size} episodes) → {candidate.candidate_id}")
+
+    return HarvestResult(
+        episodes_collected=len(episodes),
+        clusters=clusters,
+        candidates=candidates,
+        failed_distillations=failed,
+    )

--- a/src/continuous/library.py
+++ b/src/continuous/library.py
@@ -1,0 +1,92 @@
+"""Read the live skill library (`.claude/skills/`).
+
+Lifecycle operations (dedup, retrieval, deprecation) need a structured view of
+the installed skills — each skill's name, description, and body — independent of
+the git/program machinery in `registry/manager.py`. This module provides that
+read-only view by parsing each `SKILL.md`'s YAML frontmatter.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+# Same frontmatter shape used by the rest of the codebase: a leading
+# ---\n...\n--- YAML block.
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n?", re.DOTALL)
+
+
+@dataclass
+class Skill:
+    """One installed skill, parsed from its SKILL.md."""
+
+    name: str
+    description: str
+    body: str
+    path: Path
+
+    @property
+    def dir_name(self) -> str:
+        return self.path.parent.name
+
+    @property
+    def text(self) -> str:
+        """Text used for similarity comparisons: name + description.
+
+        The description is the most signal-dense, length-stable part of a skill
+        (the body varies wildly), so dedup/retrieval compare on name+description.
+        """
+        return f"{self.name}: {self.description}".strip().rstrip(":").strip()
+
+
+def parse_skill_file(path: Path) -> Skill:
+    """Parse a SKILL.md into a `Skill`. Tolerant of missing/invalid frontmatter."""
+    text = path.read_text()
+    name = path.parent.name
+    description = ""
+    body = text
+
+    match = _FRONTMATTER_RE.match(text)
+    if match:
+        body = text[match.end():]
+        try:
+            meta = yaml.safe_load(match.group(1)) or {}
+        except yaml.YAMLError:
+            meta = {}
+        if isinstance(meta, dict):
+            name = str(meta.get("name") or name)
+            description = str(meta.get("description") or "")
+    return Skill(name=name, description=description, body=body.strip(), path=path)
+
+
+class SkillLibrary:
+    """Read-only view over a `.claude/skills/` directory."""
+
+    def __init__(self, skills_dir: str | Path) -> None:
+        self.skills_dir = Path(skills_dir)
+
+    def list(self) -> list[Skill]:
+        """All skills (dirs containing a SKILL.md), sorted by name."""
+        if not self.skills_dir.is_dir():
+            return []
+        skills: list[Skill] = []
+        for child in sorted(self.skills_dir.iterdir()):
+            if not child.is_dir():
+                continue
+            skill_file = child / "SKILL.md"
+            if skill_file.is_file():
+                skills.append(parse_skill_file(skill_file))
+        return skills
+
+    def names(self) -> list[str]:
+        return [s.name for s in self.list()]
+
+    def get(self, name: str) -> Skill | None:
+        """Find a skill by frontmatter name or directory name."""
+        for skill in self.list():
+            if skill.name == name or skill.dir_name == name:
+                return skill
+        return None

--- a/src/continuous/lifecycle.py
+++ b/src/continuous/lifecycle.py
@@ -1,0 +1,290 @@
+"""Skill library lifecycle management.
+
+The continuous learner keeps adding skills; without curation the library bloats,
+skills conflict, and the agent's context degrades. This module provides the
+SkillOpt-style operations that keep the library healthy:
+
+* `find_duplicates` — group near-duplicate skills by similarity (detection).
+* `select_skills` — rank skills by relevance to a task (retrieval / top-k).
+* `evaluate_deprecation` — strike-and-retire skills that stop earning credit.
+* `propose_merge` — synthesize redundant skills into one *candidate* (apply via
+  the Phase 3 gate, never a blind live mutation here).
+* `archive_skill` / `restore_skill` — reversible filesystem archival.
+
+Design stance (Phase 2 is the safe substrate): detection and proposal only.
+Anything that would *change* the live library destructively is either reversible
+(archival) or routed through the candidate buffer for the gate to validate.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .candidates import Candidate, CandidateStore, make_candidate_id
+from .harvest import DistillerLike, slugify_skill_name
+from .library import Skill, SkillLibrary
+from .similarity import SimilarityBackend
+from .skill_stats import SkillStats, SkillStatsStore
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Dedup detection
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class DuplicateGroup:
+    """A set of skills judged near-duplicate by the similarity backend."""
+
+    skills: list[Skill]
+    max_similarity: float
+
+    @property
+    def names(self) -> list[str]:
+        return [s.name for s in self.skills]
+
+
+def find_duplicates(
+    skills: list[Skill],
+    backend: SimilarityBackend,
+    *,
+    threshold: float = 0.88,
+) -> list[DuplicateGroup]:
+    """Group skills whose pairwise similarity meets `threshold`.
+
+    Uses union-find over the similarity graph, so transitively-similar skills
+    land in one group. Singletons are dropped — only groups of 2+ are returned.
+    """
+    n = len(skills)
+    if n < 2:
+        return []
+
+    matrix = backend.pairwise([s.text for s in skills])
+
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    max_sim: dict[int, float] = {}
+    for i in range(n):
+        for j in range(i + 1, n):
+            if matrix[i][j] >= threshold:
+                union(i, j)
+
+    groups: dict[int, list[int]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(i)
+
+    result: list[DuplicateGroup] = []
+    for members in groups.values():
+        if len(members) < 2:
+            continue
+        within = [matrix[a][b] for a in members for b in members if a < b]
+        result.append(
+            DuplicateGroup(
+                skills=[skills[i] for i in members],
+                max_similarity=max(within) if within else 0.0,
+            )
+        )
+    result.sort(key=lambda g: g.max_similarity, reverse=True)
+    return result
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Retrieval / selection
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SkillMatch:
+    skill: Skill
+    score: float
+
+
+def select_skills(
+    skills: list[Skill],
+    task: str,
+    backend: SimilarityBackend,
+    *,
+    k: int = 6,
+    min_score: float = 0.0,
+) -> list[SkillMatch]:
+    """Rank skills by relevance to `task`, returning the top-k above `min_score`.
+
+    This is the guard against context bloat: instead of loading every skill, a
+    task loads only the most relevant ones. Phase 2 exposes the capability and a
+    CLI preview; wiring it into the live agent's skill-loading is a later step
+    (it changes agent behavior and must be validated by the gate first).
+    """
+    if not skills:
+        return []
+    ranked = backend.rank(task, [s.text for s in skills])
+    matches = [SkillMatch(skill=skills[i], score=score) for i, score in ranked if score >= min_score]
+    return matches[:k]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Deprecation policy
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class DeprecationReport:
+    """Outcome of one deprecation-policy window."""
+
+    candidates: list[str] = field(default_factory=list)   # past the strike limit → retire
+    struck: list[str] = field(default_factory=list)        # got a strike this window
+    recovered: list[str] = field(default_factory=list)     # had strikes, now reset
+    unused: list[str] = field(default_factory=list)         # never active → cannot judge
+
+
+def evaluate_deprecation(
+    store: SkillStatsStore,
+    library_names: list[str],
+    *,
+    baseline: float = 0.0,
+    strikes_limit: int = 3,
+    save: bool = True,
+) -> DeprecationReport:
+    """Apply one window of the deprecation policy and return what it found.
+
+    For each *active* skill (episodes_active > 0): if its `contribution` is at or
+    below `baseline` it earns a strike, otherwise its strikes reset to zero. A
+    skill that reaches `strikes_limit` consecutive strikes becomes a deprecation
+    candidate. Skills that were never active are reported as `unused` but never
+    struck — an unloaded skill has no evidence against it (it may simply be new,
+    or retrieval hasn't surfaced it yet).
+    """
+    report = DeprecationReport()
+    for name in library_names:
+        if not store.has(name) or store.get(name).episodes_active == 0:
+            report.unused.append(name)
+            continue
+        stats = store.get(name)
+        if stats.contribution <= baseline:
+            stats.deprecation_strikes += 1
+            report.struck.append(name)
+        elif stats.deprecation_strikes > 0:
+            stats.deprecation_strikes = 0
+            report.recovered.append(name)
+        store.upsert(stats)
+        if stats.deprecation_strikes >= strikes_limit:
+            report.candidates.append(name)
+    if save:
+        store.save()
+    return report
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Archival (reversible)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def archive_skill(skills_dir: str | Path, dir_name: str, archive_dir: str | Path) -> Path:
+    """Move a skill directory out of the live library into the archive.
+
+    Reversible: the skill is moved (not deleted) so `restore_skill` can bring it
+    back. Returns the archived path.
+    """
+    skills_dir = Path(skills_dir)
+    archive_dir = Path(archive_dir)
+    src = skills_dir / dir_name
+    if not src.is_dir():
+        raise FileNotFoundError(f"no skill directory: {src}")
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    dst = archive_dir / dir_name
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.move(str(src), str(dst))
+    return dst
+
+
+def restore_skill(archive_dir: str | Path, dir_name: str, skills_dir: str | Path) -> Path:
+    """Move an archived skill back into the live library."""
+    archive_dir = Path(archive_dir)
+    skills_dir = Path(skills_dir)
+    src = archive_dir / dir_name
+    if not src.is_dir():
+        raise FileNotFoundError(f"no archived skill: {src}")
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    dst = skills_dir / dir_name
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.move(str(src), str(dst))
+    return dst
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Merge (propose-only)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def build_merge_query(skills: list[Skill]) -> str:
+    """Render a prompt asking to synthesize several skills into one."""
+    lines = [
+        f"Merge the following {len(skills)} overlapping skills into ONE coherent, "
+        "non-redundant skill. Preserve every distinct rule; drop duplication. "
+        "Return a complete SKILL.md (with frontmatter) plus a name.",
+        "",
+    ]
+    for i, s in enumerate(skills, start=1):
+        lines.append(f"## Skill {i}: {s.name}")
+        lines.append(f"description: {s.description}")
+        lines.append(s.body)
+        lines.append("")
+    return "\n".join(lines)
+
+
+async def propose_merge(
+    skills: list[Skill],
+    merger: DistillerLike,
+    store: CandidateStore,
+    *,
+    source: str = "merge",
+) -> Candidate | None:
+    """Propose a merged skill as a *candidate* (not a live mutation).
+
+    The merged skill lands in the candidate buffer for review/gating; applying it
+    (replacing the originals) happens through the Phase 3 gate. Returns the
+    Candidate, or None if fewer than 2 skills or the merger produced nothing.
+    """
+    if len(skills) < 2:
+        return None
+    query = build_merge_query(skills)
+    trace = await merger.run(query)
+    output = getattr(trace, "output", None)
+    candidate_skill = getattr(output, "candidate_skill", None)
+    if not candidate_skill or not str(candidate_skill).strip():
+        return None
+
+    source_names = [s.name for s in skills]
+    raw_name = getattr(output, "skill_name", "") or f"merged-{source_names[0]}"
+    skill_name = slugify_skill_name(str(raw_name))
+    candidate = Candidate(
+        candidate_id=make_candidate_id(skill_name, source_names),
+        skill_name=skill_name,
+        skill_markdown=str(candidate_skill),
+        target_pattern=str(getattr(output, "target_pattern", "") or "merge of redundant skills"),
+        reasoning=str(getattr(output, "reasoning", "") or ""),
+        source=source,
+        cluster_key="+".join(source_names),
+        cluster_size=len(skills),
+        episode_ids=[],
+        outcome_focus="merge",
+        model_name=getattr(trace, "model", None),
+        extra={"merged_from": source_names},
+    )
+    store.save(candidate)
+    return candidate

--- a/src/continuous/loop.py
+++ b/src/continuous/loop.py
@@ -1,0 +1,272 @@
+"""The continuous-evolution tick — one pass of the always-on loop.
+
+`run_tick` composes the tested Phase 0–3 building blocks into a single, bounded
+pass:
+
+    COLLECT → CREDIT → CLUSTER → DISTILL → (auto: GATE → GRADUATE) → DEPRECATION → WATERMARK
+
+It is the unit the `evoskill watch` daemon repeats. Two modes:
+
+* **review** (default, cheap): discovery only — collect, credit, cluster, distill
+  into the candidate buffer. A human gates/applies later via `evoskill graduate`.
+* **auto**: the full pipeline — each fresh candidate is gated on a held-out
+  replay buffer and, on pass, graduated as a `program/*` branch, subject to
+  per-tick safety rails.
+
+Safety rails (auto mode): a dedup-guard skips candidates near-duplicate to live
+skills; `max_graduations` rate-limits promotions; a `CostMeter` enforces
+`cost_ceiling`; deprecation is reported and only archives when `auto_deprecate`
+is set. The watermark advances every tick so work is never repeated.
+
+Everything is injected (readers, agents, stores, manager) so the whole tick is
+testable with fakes — no real LLM, embeddings, or git.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from .candidates import Candidate, CandidateStore
+from .cluster import cluster_episodes
+from .collector import TraceCollector, TraceCursor, TraceReader
+from .episode import Outcome
+from .gate import GateVerdict, SurrogateEvaluator, build_replay_buffer, run_gate
+from .graduation import graduate
+from .harvest import distill_clusters
+from .library import SkillLibrary
+from .lifecycle import DeprecationReport, archive_skill, evaluate_deprecation
+from .similarity import SimilarityBackend
+from .skill_stats import SkillStatsStore, assign_credit_batch
+
+_Logger = Callable[[str], None]
+
+
+class CostMeter:
+    """Accumulates spend across agent calls within a tick."""
+
+    def __init__(self) -> None:
+        self.spent = 0.0
+
+    def add(self, usd: float) -> None:
+        self.spent += max(0.0, usd)
+
+    def exceeded(self, ceiling: float | None) -> bool:
+        return ceiling is not None and ceiling > 0 and self.spent >= ceiling
+
+
+class MeteredAgent:
+    """Wrap an agent so each `run()` adds its trace cost to a shared meter.
+
+    Duck-typed: works with any object exposing `async run(query) -> trace` (an
+    `src.harness.Agent`, or a test fake), so no Phase 0–3 code changes.
+    """
+
+    def __init__(self, agent: Any, meter: CostMeter) -> None:
+        self._agent = agent
+        self._meter = meter
+
+    async def run(self, query: str) -> Any:
+        trace = await self._agent.run(query)
+        self._meter.add(float(getattr(trace, "total_cost_usd", 0.0) or 0.0))
+        return trace
+
+
+@dataclass
+class TickConfig:
+    """Policy knobs for one tick (the collaborators are passed separately)."""
+
+    mode: str = "review"                  # "review" | "auto"
+    window: int = 200
+    focus: Outcome = Outcome.FAILURE
+    min_cluster_size: int = 3
+    similarity_threshold: float = 0.3
+    max_candidates: int | None = None
+    concurrency: int = 4
+    # gate / graduation (auto mode)
+    graduation_threshold: float = 0.6
+    shadow_eval_size: int = 10
+    max_graduations: int = 2
+    dedupe_similarity: float = 0.88
+    # deprecation
+    deprecation_baseline: float = 0.0
+    deprecation_strikes: int = 3
+    auto_deprecate: bool = False
+    # cost
+    cost_ceiling: float | None = None
+
+
+@dataclass
+class TickReport:
+    """What one tick did."""
+
+    episodes_collected: int = 0
+    credited: int = 0
+    candidates: list[Candidate] = field(default_factory=list)
+    gated: dict[str, GateVerdict] = field(default_factory=dict)
+    graduated: list[str] = field(default_factory=list)
+    skipped_duplicates: list[str] = field(default_factory=list)
+    deprecation: DeprecationReport | None = None
+    archived: list[str] = field(default_factory=list)
+    cost_usd: float = 0.0
+    stopped_reason: str | None = None
+
+    @property
+    def num_candidates(self) -> int:
+        return len(self.candidates)
+
+    @property
+    def num_graduated(self) -> int:
+        return len(self.graduated)
+
+
+def _candidate_text(candidate: Candidate) -> str:
+    """Comparable text for the dedup guard (mirrors Skill.text shape)."""
+    return f"{candidate.skill_name}: {candidate.target_pattern}".strip().rstrip(":").strip()
+
+
+async def run_tick(
+    *,
+    readers: list[TraceReader],
+    store: CandidateStore,
+    distiller: Any,
+    cursor: TraceCursor | None = None,
+    verifier: Any | None = None,
+    skills_dir: str | Path | None = None,
+    stats_store: SkillStatsStore | None = None,
+    similarity_backend: SimilarityBackend | None = None,
+    manager: Any | None = None,
+    archive_dir: str | Path | None = None,
+    library: SkillLibrary | None = None,
+    config: TickConfig | None = None,
+    log: _Logger | None = None,
+) -> TickReport:
+    """Run one continuous-evolution tick. See module docstring for the flow."""
+    cfg = config or TickConfig()
+    emit = log or (lambda _m: None)
+    meter = CostMeter()
+    report = TickReport()
+
+    # 1. COLLECT — advance the watermark so each tick sees only new episodes.
+    episodes = TraceCollector(readers, cursor=cursor).collect(advance=True, limit=cfg.window)
+    report.episodes_collected = len(episodes)
+    emit(f"collected {len(episodes)} episode(s)")
+
+    # 2. CREDIT — attribute outcomes to the skills that were active.
+    if stats_store is not None:
+        report.credited = assign_credit_batch(stats_store, episodes)
+
+    # 3-4. CLUSTER + DISTILL
+    clusters = cluster_episodes(
+        episodes, focus=cfg.focus, min_cluster_size=cfg.min_cluster_size,
+        similarity_threshold=cfg.similarity_threshold, max_clusters=cfg.max_candidates,
+    )
+    candidates, _failed, _cost = await distill_clusters(
+        clusters, MeteredAgent(distiller, meter), store,
+        source="watch", concurrency=cfg.concurrency, log=emit,
+    )
+    report.candidates = candidates
+    emit(f"distilled {len(candidates)} candidate(s)")
+
+    lib = library or (SkillLibrary(skills_dir) if skills_dir is not None else None)
+
+    # 5/9. DEPRECATION — report strikes; archive only when explicitly enabled.
+    if stats_store is not None and lib is not None:
+        report.deprecation = evaluate_deprecation(
+            stats_store, lib.names(),
+            baseline=cfg.deprecation_baseline, strikes_limit=cfg.deprecation_strikes,
+        )
+        if (cfg.mode == "auto" and cfg.auto_deprecate and archive_dir is not None
+                and report.deprecation.candidates):
+            for name in report.deprecation.candidates:
+                skill = lib.get(name)
+                if skill is None:
+                    continue
+                try:
+                    archive_skill(skills_dir, skill.dir_name, archive_dir)
+                    report.archived.append(name)
+                except FileNotFoundError:
+                    continue
+
+    # review mode = discovery only; a human gates/applies later.
+    if cfg.mode != "auto":
+        report.cost_usd = meter.spent
+        return report
+
+    # 6-8. GATE + GRADUATE (auto mode)
+    if verifier is None:
+        report.stopped_reason = "no verifier for auto mode"
+        report.cost_usd = meter.spent
+        return report
+
+    existing_texts = [s.text for s in lib.list()] if lib is not None else []
+    evaluator = SurrogateEvaluator(MeteredAgent(verifier, meter), max_tasks=cfg.shadow_eval_size)
+    graduations = 0
+
+    for candidate in candidates:
+        if meter.exceeded(cfg.cost_ceiling):
+            report.stopped_reason = "cost_ceiling"
+            break
+        if graduations >= cfg.max_graduations:
+            report.stopped_reason = "max_graduations"
+            break
+
+        # Dedup guard: don't graduate something the library already covers.
+        if similarity_backend is not None and existing_texts:
+            ranked = similarity_backend.rank(_candidate_text(candidate), existing_texts)
+            if ranked and ranked[0][1] >= cfg.dedupe_similarity:
+                report.skipped_duplicates.append(candidate.candidate_id)
+                continue
+
+        replay = build_replay_buffer(episodes, candidate, size=cfg.shadow_eval_size)
+        verdict = await run_gate(candidate, replay, evaluator, threshold=cfg.graduation_threshold)
+        report.gated[candidate.candidate_id] = verdict
+
+        # Record the verdict on the buffered candidate for audit.
+        candidate.extra["gate_score"] = verdict.score
+        candidate.extra["gate_passed"] = verdict.passed
+        store.save(candidate)
+
+        if verdict.passed:
+            graduate(
+                candidate, skills_dir=skills_dir, store=store, manager=manager,
+                archive_dir=archive_dir, gate_score=verdict.score,
+            )
+            report.graduated.append(candidate.candidate_id)
+            graduations += 1
+            emit(f"graduated '{candidate.skill_name}' (score {verdict.score:.2f})")
+
+    report.cost_usd = meter.spent
+    return report
+
+
+def run_watch_loop(
+    tick_fn: Callable[[], TickReport],
+    *,
+    once: bool = False,
+    max_ticks: int | None = None,
+    interval_sec: float = 600,
+    sleep: Callable[[float], None] | None = None,
+    log: _Logger | None = None,
+) -> int:
+    """Drive `tick_fn` on a schedule. Returns the number of ticks run.
+
+    Stops after one tick if `once`, after `max_ticks` ticks if set, or on
+    KeyboardInterrupt. `sleep` is injectable so tests don't actually wait.
+    """
+    import time as _time
+
+    do_sleep = sleep or _time.sleep
+    emit = log or (lambda _m: None)
+    n = 0
+    try:
+        while True:
+            tick_fn()
+            n += 1
+            if once or (max_ticks is not None and n >= max_ticks):
+                break
+            do_sleep(interval_sec)
+    except KeyboardInterrupt:
+        emit("watch interrupted; stopping.")
+    return n

--- a/src/continuous/signals.py
+++ b/src/continuous/signals.py
@@ -1,0 +1,92 @@
+"""Outcome-signal extraction for continuous evolution.
+
+An `OutcomeSignal` answers "did this episode succeed, and how sure are we?"
+without necessarily having ground truth.
+
+Phase 0 ships exactly one extractor — `signal_from_reward` — which reads a
+Harbor verifier reward (ground truth, confidence 1.0). The labeled
+`arena-tracjectories/` corpus and any live Harbor run both expose such a
+reward, so this is enough to bootstrap and test the whole pipeline.
+
+The richer *implicit* extractors for the unlabeled production case
+(tests-passed, diff-committed, no-retry, user feedback) are Phase 5. They are
+declared as `SignalKind` values in `episode.py` but deliberately not guessed at
+here — implementing them against trace formats we cannot yet validate would be
+assuming. `SignalExtractor` defines the contract they will implement so adding
+them later is additive.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from .episode import Outcome, OutcomeSignal, SignalKind, TaskEpisode
+
+
+def clamp01(x: float) -> float:
+    """Clamp a value into [0.0, 1.0]."""
+    if x < 0.0:
+        return 0.0
+    if x > 1.0:
+        return 1.0
+    return x
+
+
+def signal_from_reward(
+    reward: float,
+    *,
+    success_threshold: float = 1.0,
+    evidence: str | None = None,
+) -> OutcomeSignal:
+    """Build a ground-truth `OutcomeSignal` from a verifier reward.
+
+    Harbor verifiers emit a reward in [0, 1]. We treat `reward >= success_threshold`
+    as success. The default threshold is strict (1.0) because most Harbor verifiers
+    are pass/fail; partial credit (0 < reward < 1) is recorded in `value` but still
+    counts as a failure so distillation clusters genuinely-failed attempts. The
+    threshold is configurable for graded verifiers.
+
+    Confidence is 1.0: a verifier reward is ground truth, not an estimate.
+    """
+    value = clamp01(reward)
+    outcome = Outcome.SUCCESS if reward >= success_threshold else Outcome.FAILURE
+    if evidence is None:
+        evidence = f"verifier reward {reward:g} (threshold {success_threshold:g})"
+    return OutcomeSignal(
+        kind=SignalKind.VERIFIER_REWARD,
+        outcome=outcome,
+        value=value,
+        confidence=1.0,
+        evidence=evidence,
+    )
+
+
+def no_signal(evidence: str = "no outcome signal available") -> OutcomeSignal:
+    """A null signal: outcome unknown, zero confidence.
+
+    Used when a reader cannot recover any outcome (e.g. a raw log with no
+    verifier and no implicit cues). Such episodes are still useful context but
+    must not be treated as labeled.
+    """
+    return OutcomeSignal(
+        kind=SignalKind.NONE,
+        outcome=Outcome.UNKNOWN,
+        value=0.0,
+        confidence=0.0,
+        evidence=evidence,
+    )
+
+
+class SignalExtractor(Protocol):
+    """Contract for implicit/surrogate signal extractors (Phase 3 / Phase 5).
+
+    An extractor inspects an episode (and any side-channel evidence already
+    attached to it) and returns an `OutcomeSignal`, or `None` if it has nothing
+    to say. Multiple extractors will be combined by the gate in later phases;
+    the contract is defined now so that work is purely additive.
+    """
+
+    kind: SignalKind
+
+    def extract(self, episode: TaskEpisode) -> OutcomeSignal | None:  # pragma: no cover - protocol
+        ...

--- a/src/continuous/similarity.py
+++ b/src/continuous/similarity.py
@@ -1,0 +1,273 @@
+"""Pluggable text-similarity backends for skill dedup and retrieval.
+
+Two backends behind one interface:
+
+* `EmbeddingSimilarity` — semantic similarity via a provider embedding model
+  (the configured default). Embeddings are cached on disk by content hash so
+  unchanged skills are never re-embedded — important because every API call
+  costs money.
+* `LexicalSimilarity` — pure-Python TF-IDF cosine (reuses the Phase 1
+  tokenizer). Zero deps, offline, free. Used as the graceful fallback whenever
+  embeddings are unavailable (no API key, unsupported provider, or import
+  error) so lifecycle operations always work and the test-suite stays hermetic.
+
+`make_similarity_backend()` picks the backend from config and degrades to
+lexical rather than failing hard.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from abc import ABC, abstractmethod
+from collections import Counter
+from pathlib import Path
+from typing import Callable
+
+from .cluster import _tokenize
+
+EmbedFn = Callable[[list[str]], list[list[float]]]
+
+# Provider → OpenAI-compatible base_url. Providers absent here fall back to
+# lexical similarity (their embeddings APIs are not OpenAI-compatible).
+_OPENAI_COMPATIBLE_BASE_URLS: dict[str, str | None] = {
+    "openai": None,
+    "openrouter": "https://openrouter.ai/api/v1",
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Backend interface
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class SimilarityBackend(ABC):
+    """Computes similarity between short texts (skill descriptions / tasks)."""
+
+    name: str = "similarity"
+
+    @abstractmethod
+    def pairwise(self, texts: list[str]) -> list[list[float]]:
+        """Return an NxN cosine-similarity matrix for `texts`."""
+
+    @abstractmethod
+    def rank(self, query: str, candidates: list[str]) -> list[tuple[int, float]]:
+        """Return (index, similarity) for each candidate, sorted high→low."""
+
+
+def _cosine_dense(a: list[float], b: list[float]) -> float:
+    if not a or not b:
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _cosine_sparse(a: dict[str, float], b: dict[str, float]) -> float:
+    if not a or not b:
+        return 0.0
+    if len(a) > len(b):
+        a, b = b, a
+    dot = sum(w * b.get(t, 0.0) for t, w in a.items())
+    na = math.sqrt(sum(w * w for w in a.values()))
+    nb = math.sqrt(sum(w * w for w in b.values()))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Lexical backend
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class LexicalSimilarity(SimilarityBackend):
+    """TF-IDF cosine over the supplied text set. No external dependencies."""
+
+    name = "lexical"
+
+    def _vectorize(self, texts: list[str]) -> list[dict[str, float]]:
+        token_lists = [_tokenize(t) for t in texts]
+        n = len(token_lists)
+        df: Counter[str] = Counter()
+        for tokens in token_lists:
+            df.update(set(tokens))
+        vectors: list[dict[str, float]] = []
+        for tokens in token_lists:
+            if not tokens:
+                vectors.append({})
+                continue
+            tf = Counter(tokens)
+            total = len(tokens)
+            vec = {
+                term: (count / total) * (math.log((1 + n) / (1 + df[term])) + 1.0)
+                for term, count in tf.items()
+            }
+            vectors.append(vec)
+        return vectors
+
+    def pairwise(self, texts: list[str]) -> list[list[float]]:
+        vecs = self._vectorize(texts)
+        n = len(vecs)
+        matrix = [[0.0] * n for _ in range(n)]
+        for i in range(n):
+            matrix[i][i] = 1.0 if vecs[i] else 0.0
+            for j in range(i + 1, n):
+                sim = _cosine_sparse(vecs[i], vecs[j])
+                matrix[i][j] = matrix[j][i] = sim
+        return matrix
+
+    def rank(self, query: str, candidates: list[str]) -> list[tuple[int, float]]:
+        vecs = self._vectorize([query, *candidates])
+        qv = vecs[0]
+        scored = [(i, _cosine_sparse(qv, vecs[i + 1])) for i in range(len(candidates))]
+        scored.sort(key=lambda kv: kv[1], reverse=True)
+        return scored
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Embedding backend (+ disk cache)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class EmbeddingCache:
+    """Disk cache of text→embedding keyed by content hash."""
+
+    def __init__(self, path: str | Path | None) -> None:
+        self.path = Path(path) if path is not None else None
+        self._cache: dict[str, list[float]] = {}
+        self._load()
+
+    @staticmethod
+    def _key(text: str) -> str:
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+    def _load(self) -> None:
+        if self.path is None or not self.path.is_file():
+            return
+        try:
+            data = json.loads(self.path.read_text())
+            if isinstance(data, dict):
+                self._cache = {k: list(v) for k, v in data.items()}
+        except (OSError, ValueError):
+            self._cache = {}
+
+    def save(self) -> None:
+        if self.path is None:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self._cache))
+
+    def get(self, text: str) -> list[float] | None:
+        return self._cache.get(self._key(text))
+
+    def put(self, text: str, vector: list[float]) -> None:
+        self._cache[self._key(text)] = vector
+
+
+class EmbeddingSimilarity(SimilarityBackend):
+    """Semantic similarity via a (cached) embedding function."""
+
+    name = "embedding"
+
+    def __init__(self, embed_fn: EmbedFn, cache: EmbeddingCache | None = None) -> None:
+        self._embed_fn = embed_fn
+        self._cache = cache
+
+    def _embed(self, texts: list[str]) -> list[list[float]]:
+        if self._cache is None:
+            return self._embed_fn(texts) if texts else []
+        # Only embed cache misses, preserving order.
+        missing = [t for t in texts if self._cache.get(t) is None]
+        if missing:
+            # De-dup misses before the API call.
+            unique_missing = list(dict.fromkeys(missing))
+            fresh = self._embed_fn(unique_missing)
+            for text, vec in zip(unique_missing, fresh):
+                self._cache.put(text, vec)
+            self._cache.save()
+        return [self._cache.get(t) or [] for t in texts]
+
+    def pairwise(self, texts: list[str]) -> list[list[float]]:
+        vecs = self._embed(texts)
+        n = len(vecs)
+        matrix = [[0.0] * n for _ in range(n)]
+        for i in range(n):
+            matrix[i][i] = 1.0
+            for j in range(i + 1, n):
+                sim = _cosine_dense(vecs[i], vecs[j])
+                matrix[i][j] = matrix[j][i] = sim
+        return matrix
+
+    def rank(self, query: str, candidates: list[str]) -> list[tuple[int, float]]:
+        vecs = self._embed([query, *candidates])
+        qv = vecs[0]
+        scored = [(i, _cosine_dense(qv, vecs[i + 1])) for i in range(len(candidates))]
+        scored.sort(key=lambda kv: kv[1], reverse=True)
+        return scored
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Provider embedder + factory
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def make_openai_embedder(model: str, api_key: str, *, base_url: str | None = None) -> EmbedFn:
+    """Return a sync embed function backed by an OpenAI-compatible API."""
+    import openai  # imported lazily; raises ImportError if absent
+
+    client = openai.OpenAI(api_key=api_key, base_url=base_url)
+
+    def _embed(texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        response = client.embeddings.create(model=model, input=texts)
+        return [list(item.embedding) for item in response.data]
+
+    return _embed
+
+
+def make_similarity_backend(
+    *,
+    backend: str = "embedding",
+    provider: str = "openai",
+    model: str = "text-embedding-3-small",
+    api_key: str | None = None,
+    cache_path: str | Path | None = None,
+    log: Callable[[str], None] | None = None,
+) -> SimilarityBackend:
+    """Build the configured similarity backend, degrading to lexical on any gap.
+
+    Falls back to `LexicalSimilarity` (with a logged reason) when:
+      - backend != "embedding", or
+      - no API key is available, or
+      - the provider is not OpenAI-compatible, or
+      - the openai package cannot be imported.
+    """
+    emit = log or (lambda _m: None)
+
+    if backend != "embedding":
+        return LexicalSimilarity()
+
+    provider_norm = (provider or "").strip().lower()
+    if provider_norm not in _OPENAI_COMPATIBLE_BASE_URLS:
+        emit(f"embedding provider '{provider}' is not OpenAI-compatible; using lexical similarity.")
+        return LexicalSimilarity()
+    if not api_key:
+        emit("no embedding API key found; using lexical similarity.")
+        return LexicalSimilarity()
+
+    try:
+        embedder = make_openai_embedder(
+            model, api_key, base_url=_OPENAI_COMPATIBLE_BASE_URLS[provider_norm]
+        )
+    except ImportError:
+        emit("openai package not installed; using lexical similarity.")
+        return LexicalSimilarity()
+
+    cache = EmbeddingCache(cache_path) if cache_path is not None else None
+    return EmbeddingSimilarity(embedder, cache)

--- a/src/continuous/skill_stats.py
+++ b/src/continuous/skill_stats.py
@@ -1,0 +1,136 @@
+"""Per-skill statistics and credit assignment.
+
+Continuous evolution needs to know which skills *earn their place*. As episodes
+arrive, `assign_credit` attributes each outcome to the skills that were active
+during the attempt, accumulating usage and a credit-weighted contribution score.
+The deprecation policy (in `lifecycle.py`) later reads these stats to retire
+skills that stop pulling their weight.
+
+Stats live in `.evoskill/continuous/skill_stats.json` rather than the
+git-versioned `program.yaml`: credit accrues continuously from deployment
+traces, and high-frequency updates should not churn the program's git history.
+A snapshot can be folded into `program.yaml` at graduation time (Phase 3).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from .episode import TaskEpisode
+
+
+class SkillStats(BaseModel):
+    """Accumulated usage/credit for one skill."""
+
+    name: str
+    episodes_active: int = Field(default=0, description="Times this skill was loaded during an attempt")
+    success_when_active: int = Field(default=0, description="Successful attempts while active")
+    contribution: float = Field(default=0.0, description="Credit-weighted share of wins")
+    deprecation_strikes: int = Field(default=0, description="Consecutive windows below baseline")
+    last_credited_at: str | None = Field(default=None, description="ISO time of last credit update")
+
+    @property
+    def success_rate(self) -> float:
+        return self.success_when_active / self.episodes_active if self.episodes_active else 0.0
+
+
+class SkillStatsStore:
+    """Persist a map of skill name → `SkillStats`."""
+
+    DEFAULT_SUBPATH = Path(".evoskill") / "continuous" / "skill_stats.json"
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path) if path is not None else self.DEFAULT_SUBPATH
+        self._stats: dict[str, SkillStats] = {}
+        self.load()
+
+    def load(self) -> None:
+        if not self.path.is_file():
+            self._stats = {}
+            return
+        try:
+            data = json.loads(self.path.read_text())
+        except (OSError, ValueError):
+            self._stats = {}
+            return
+        stats: dict[str, SkillStats] = {}
+        if isinstance(data, dict):
+            for name, raw in data.items():
+                try:
+                    stats[name] = SkillStats.model_validate(raw)
+                except ValueError:
+                    continue
+        self._stats = stats
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {name: s.model_dump() for name, s in self._stats.items()}
+        self.path.write_text(json.dumps(payload, indent=2))
+
+    def get(self, name: str) -> SkillStats:
+        """Get stats for a skill, creating an empty record if absent."""
+        if name not in self._stats:
+            self._stats[name] = SkillStats(name=name)
+        return self._stats[name]
+
+    def has(self, name: str) -> bool:
+        return name in self._stats
+
+    def upsert(self, stats: SkillStats) -> None:
+        self._stats[stats.name] = stats
+
+    def all(self) -> list[SkillStats]:
+        return list(self._stats.values())
+
+    def remove(self, name: str) -> None:
+        self._stats.pop(name, None)
+
+
+def assign_credit(
+    store: SkillStatsStore,
+    episode: TaskEpisode,
+    *,
+    timestamp: str | None = None,
+) -> bool:
+    """Attribute one episode's outcome to the skills that were active.
+
+    Each active skill gets `episodes_active += 1`. On success, every active
+    skill also gets `success_when_active += 1` and an equal share (1/N) of the
+    win added to `contribution` — so a skill that is the *sole* active skill in
+    a win earns full credit, while one of many shares it.
+
+    Episodes with no `skills_active` (e.g. raw Harbor trajectories that don't
+    record loaded skills) are skipped. Returns True if any credit was assigned.
+    """
+    active = episode.skills_active
+    if not active:
+        return False
+    ts = timestamp or datetime.now().isoformat()
+    share = 1.0 / len(active) if episode.is_success else 0.0
+    for name in active:
+        stats = store.get(name)
+        stats.episodes_active += 1
+        if episode.is_success:
+            stats.success_when_active += 1
+            stats.contribution += share
+        stats.last_credited_at = ts
+        store.upsert(stats)
+    return True
+
+
+def assign_credit_batch(
+    store: SkillStatsStore,
+    episodes: list[TaskEpisode],
+    *,
+    timestamp: str | None = None,
+    save: bool = True,
+) -> int:
+    """Assign credit for a batch of episodes. Returns the number credited."""
+    credited = sum(assign_credit(store, ep, timestamp=timestamp) for ep in episodes)
+    if save:
+        store.save()
+    return credited

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -4,6 +4,7 @@ from .tool_generator import ToolGeneratorResponse
 from .prompt_generator import PromptGeneratorResponse
 from .skill_proposer import SkillProposerResponse
 from .prompt_proposer import PromptProposerResponse
+from .skill_distiller import SkillDistillerResponse
 
 __all__ = [
     "AgentResponse",
@@ -12,4 +13,5 @@ __all__ = [
     "PromptGeneratorResponse",
     "SkillProposerResponse",
     "PromptProposerResponse",
+    "SkillDistillerResponse",
 ]

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -5,6 +5,7 @@ from .prompt_generator import PromptGeneratorResponse
 from .skill_proposer import SkillProposerResponse
 from .prompt_proposer import PromptProposerResponse
 from .skill_distiller import SkillDistillerResponse
+from .surrogate_verifier import SurrogateVerifierResponse
 
 __all__ = [
     "AgentResponse",
@@ -14,4 +15,5 @@ __all__ = [
     "SkillProposerResponse",
     "PromptProposerResponse",
     "SkillDistillerResponse",
+    "SurrogateVerifierResponse",
 ]

--- a/src/schemas/skill_distiller.py
+++ b/src/schemas/skill_distiller.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel, Field
+
+
+class SkillDistillerResponse(BaseModel):
+    """Response from the skill distiller agent.
+
+    The distiller reads a cluster of *similar* episodes (recurring failures or
+    notable successes) and distills one reusable, generalizable skill that would
+    help future similar tasks — not a memorized fix for the specific episodes.
+    """
+
+    skill_name: str = Field(
+        description="kebab-case skill name; also the SKILL.md directory/frontmatter name"
+    )
+    candidate_skill: str = Field(
+        description="The full SKILL.md content, including YAML frontmatter (name, description)"
+    )
+    target_pattern: str = Field(
+        description="The recurring task pattern / failure mode this skill addresses"
+    )
+    reasoning: str = Field(
+        description="Why this generalizes across the cluster rather than memorizing specifics"
+    )

--- a/src/schemas/surrogate_verifier.py
+++ b/src/schemas/surrogate_verifier.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel, Field
+
+
+class SurrogateVerifierResponse(BaseModel):
+    """Response from the surrogate verifier agent.
+
+    The verifier judges a *candidate* skill — in an isolated session, with no
+    access to how the skill was distilled — by synthesizing test assertions from
+    the skill and a set of held-out task descriptions, then deciding whether the
+    skill is correct and generalizable (not a memorized one-off).
+    """
+
+    score: float = Field(
+        description="Confidence in [0,1] that the skill helps and generalizes"
+    )
+    verdict: bool = Field(
+        description="Whether the skill should pass the gate (correct + generalizable)"
+    )
+    assertions: list[str] = Field(
+        default_factory=list,
+        description="Test assertions the verifier synthesized to judge the skill",
+    )
+    reasoning: str = Field(
+        default="", description="Why the skill passes or fails, with diagnostics"
+    )

--- a/tests/continuous/conftest.py
+++ b/tests/continuous/conftest.py
@@ -151,6 +151,35 @@ def make_trial(
     return trial
 
 
+def make_episode(
+    episode_id: str,
+    task_text: str,
+    *,
+    outcome=None,
+    tools: list[str] | None = None,
+    source: str = "harbor",
+    final_output: str = "",
+):
+    """Build a TaskEpisode for clustering/harvest tests."""
+    from src.continuous.episode import ActionStep, Outcome, TaskEpisode, ToolCall
+
+    outcome = outcome if outcome is not None else Outcome.FAILURE
+    actions = []
+    if tools:
+        actions = [ActionStep(
+            step_id=1, source="agent",
+            tool_calls=[ToolCall(function_name=t) for t in tools],
+        )]
+    return TaskEpisode(
+        episode_id=episode_id,
+        source=source,
+        task_text=task_text,
+        actions=actions,
+        final_output=final_output,
+        outcome=outcome,
+    )
+
+
 @pytest.fixture
 def atif_v12():
     return _atif_v12_payload()

--- a/tests/continuous/conftest.py
+++ b/tests/continuous/conftest.py
@@ -1,0 +1,171 @@
+"""Fixtures for continuous-evolution tests.
+
+Builders here mirror the *real* Harbor/ATIF trial layout confirmed against the
+`arena-tracjectories/` corpus, so tests stay hermetic (no dependency on any
+external path) while exercising the exact shapes the readers see in the wild.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _atif_v12_payload(*, with_tools: bool = True) -> dict:
+    """An ATIF v1.2 trajectory (goose-style): no per-step timestamp/cost."""
+    steps = [
+        {
+            "step_id": 1,
+            "source": "agent",
+            "message": "I'll find the answer.",
+            "reasoning_content": "I need to find the average federal deficit for Q1 1994-1996.",
+            "tool_calls": [
+                {
+                    "tool_call_id": "call_a",
+                    "function_name": "analyze",
+                    "arguments": {"path": "/app/resources", "max_depth": 2},
+                }
+            ]
+            if with_tools
+            else [],
+            "observation": {
+                "results": [{"source_call_id": "call_a", "content": "0 files found"}]
+            }
+            if with_tools
+            else {},
+        },
+        {
+            "step_id": 2,
+            "source": "agent",
+            "message": "[tool call]",
+            "reasoning_content": "The answer is 12345.",
+        },
+    ]
+    return {
+        "schema_version": "ATIF-v1.2",
+        "session_id": "sess-v12",
+        "agent": {"name": "goose", "version": "1.36.0", "model_name": "openrouter/foo"},
+        "steps": steps,
+        "final_metrics": {
+            "total_prompt_tokens": 98662,
+            "total_completion_tokens": 32888,
+            "total_steps": 2,
+            "extra": {"total_tokens": 131550},
+        },
+    }
+
+
+def _atif_v16_payload() -> dict:
+    """An ATIF v1.6 trajectory (opencode-style): per-step timestamp + total_cost_usd."""
+    return {
+        "schema_version": "ATIF-v1.6",
+        "session_id": "ses_v16",
+        "agent": {"name": "opencode", "version": "1.14.39", "model_name": "openrouter/bar"},
+        "steps": [
+            {
+                "step_id": 1,
+                "timestamp": "2026-05-06T13:40:00Z",
+                "source": "agent",
+                "model_name": "openrouter/bar",
+                "message": "Working on it.",
+                "reasoning_content": "Inspect the workspace first.",
+                "tool_calls": [
+                    {"tool_call_id": "c1", "function_name": "glob", "arguments": {"pattern": "**/*.json"}},
+                    {"tool_call_id": "c2", "function_name": "bash", "arguments": {"command": "ls -la"}},
+                ],
+                "observation": {
+                    "results": [
+                        {"source_call_id": "c1", "content": "/app/hand1.json"},
+                        {"source_call_id": "c2", "content": "total 20"},
+                    ]
+                },
+                "metrics": {"prompt_tokens": 100},
+            },
+            {
+                "step_id": 2,
+                "timestamp": "2026-05-06T13:41:00Z",
+                "source": "agent",
+                "message": "Done: result is 42.",
+                "reasoning_content": "",
+            },
+        ],
+        "final_metrics": {
+            "total_prompt_tokens": 1562256,
+            "total_completion_tokens": 18242,
+            "total_cached_tokens": 1490683,
+            "total_cost_usd": 0.154,
+            "total_steps": 2,
+        },
+    }
+
+
+def make_trial(
+    jobs_root: Path,
+    trial_name: str,
+    *,
+    payload: dict | None = None,
+    reward: str | None = "1",
+    task_name: str | None = None,
+    goose_log: bool = False,
+) -> Path:
+    """Create a Harbor-style trial dir with the standard layout.
+
+        <jobs_root>/<job>/<trial_name>/
+            agent/trajectory.json   (+ optional goose.txt)
+            verifier/reward.txt     (optional)
+            result.json             (optional)
+    """
+    trial = jobs_root / "job-1" / trial_name
+    agent_dir = trial / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+
+    payload = payload if payload is not None else _atif_v12_payload()
+    (agent_dir / "trajectory.json").write_text(json.dumps(payload))
+
+    if reward is not None:
+        verifier = trial / "verifier"
+        verifier.mkdir(parents=True, exist_ok=True)
+        (verifier / "reward.txt").write_text(reward)
+
+    if task_name is not None:
+        (trial / "result.json").write_text(json.dumps({"task_name": task_name}))
+
+    if goose_log:
+        lines = [
+            {"type": "message", "message": {"id": "m1", "role": "assistant",
+             "content": [{"type": "thinking", "thinking": "Let me "}]}},
+            {"type": "message", "message": {"id": "m1", "role": "assistant",
+             "content": [{"type": "thinking", "thinking": "think."}]}},
+            {"type": "message", "message": {"id": "m1", "role": "assistant",
+             "content": [{"type": "text", "text": "Answer: 42"}]}},
+            {"type": "message", "message": {"id": "m2", "role": "assistant",
+             "content": [{"type": "toolRequest", "id": "t1",
+                          "toolCall": {"name": "bash"}}]}},
+        ]
+        (agent_dir / "goose.txt").write_text(
+            "Loading recipe: harbor-task\n" + "\n".join(json.dumps(x) for x in lines)
+        )
+
+    return trial
+
+
+@pytest.fixture
+def atif_v12():
+    return _atif_v12_payload()
+
+
+@pytest.fixture
+def atif_v16():
+    return _atif_v16_payload()
+
+
+@pytest.fixture
+def jobs_root(tmp_path):
+    """A jobs root with three labeled trials: pass, fail, and partial."""
+    root = tmp_path / "harbor_jobs"
+    make_trial(root, "task-pass__AAA", reward="1", task_name="bench/task-pass")
+    make_trial(root, "task-fail__BBB", reward="0", task_name="bench/task-fail")
+    make_trial(root, "task-partial__CCC", reward="0.5", task_name="bench/task-partial")
+    return root

--- a/tests/continuous/test_candidates.py
+++ b/tests/continuous/test_candidates.py
@@ -1,0 +1,86 @@
+"""Tests for the candidate buffer."""
+
+from __future__ import annotations
+
+from src.continuous.candidates import Candidate, CandidateStore, make_candidate_id
+
+
+def _candidate(**kw) -> Candidate:
+    base = dict(
+        candidate_id="skill-x-abc123",
+        skill_name="skill-x",
+        skill_markdown="---\nname: skill-x\ndescription: d\n---\nbody",
+        target_pattern="pattern",
+        episode_ids=["e1", "e2"],
+        cluster_size=2,
+    )
+    base.update(kw)
+    return Candidate(**base)
+
+
+class TestMakeCandidateId:
+    def test_stable_and_order_independent(self):
+        a = make_candidate_id("my-skill", ["e2", "e1"])
+        b = make_candidate_id("my-skill", ["e1", "e2"])
+        assert a == b
+        assert a.startswith("my-skill-")
+
+    def test_different_episodes_differ(self):
+        assert make_candidate_id("s", ["e1"]) != make_candidate_id("s", ["e2"])
+
+    def test_empty_name_falls_back(self):
+        assert make_candidate_id("", ["e1"]).startswith("skill-")
+
+
+class TestCandidateStore:
+    def test_save_writes_metadata_and_skill(self, tmp_path):
+        store = CandidateStore(tmp_path / "cands")
+        target = store.save(_candidate())
+        assert (target / "candidate.json").is_file()
+        assert (target / "SKILL.md").read_text().startswith("---")
+
+    def test_save_sets_created_at(self, tmp_path):
+        store = CandidateStore(tmp_path / "cands")
+        store.save(_candidate(), timestamp="2026-01-01T00:00:00")
+        got = store.get("skill-x-abc123")
+        assert got.created_at == "2026-01-01T00:00:00"
+
+    def test_save_preserves_existing_created_at(self, tmp_path):
+        store = CandidateStore(tmp_path / "cands")
+        store.save(_candidate(created_at="2020-01-01T00:00:00"), timestamp="2026-01-01T00:00:00")
+        assert store.get("skill-x-abc123").created_at == "2020-01-01T00:00:00"
+
+    def test_get_missing_returns_none(self, tmp_path):
+        assert CandidateStore(tmp_path).get("nope") is None
+
+    def test_get_corrupt_returns_none(self, tmp_path):
+        store = CandidateStore(tmp_path / "cands")
+        d = store.dir_for("broken")
+        d.mkdir(parents=True)
+        (d / "candidate.json").write_text("{bad json")
+        assert store.get("broken") is None
+
+    def test_list_newest_first(self, tmp_path):
+        store = CandidateStore(tmp_path / "cands")
+        store.save(_candidate(candidate_id="a", skill_name="a"), timestamp="2026-01-01T00:00:00")
+        store.save(_candidate(candidate_id="b", skill_name="b"), timestamp="2026-02-01T00:00:00")
+        ids = [c.candidate_id for c in store.list()]
+        assert ids == ["b", "a"]
+
+    def test_list_ignores_non_dirs_and_missing_root(self, tmp_path):
+        assert CandidateStore(tmp_path / "absent").list() == []
+        store = CandidateStore(tmp_path / "cands")
+        store.root.mkdir(parents=True)
+        (store.root / "stray.txt").write_text("noise")
+        store.save(_candidate())
+        assert len(store.list()) == 1
+
+    def test_set_status(self, tmp_path):
+        store = CandidateStore(tmp_path / "cands")
+        store.save(_candidate())
+        updated = store.set_status("skill-x-abc123", "graduated")
+        assert updated.status == "graduated"
+        assert store.get("skill-x-abc123").status == "graduated"
+
+    def test_set_status_missing(self, tmp_path):
+        assert CandidateStore(tmp_path).set_status("nope", "rejected") is None

--- a/tests/continuous/test_cluster.py
+++ b/tests/continuous/test_cluster.py
@@ -1,0 +1,98 @@
+"""Tests for episode clustering."""
+
+from __future__ import annotations
+
+from src.continuous.cluster import cluster_episodes
+from src.continuous.episode import Outcome
+
+from .conftest import make_episode
+
+
+# Two coherent topics with distinct vocabulary.
+def _deficit(i):
+    return make_episode(f"def-{i}", "compute the federal budget deficit for fiscal year quarter")
+
+
+def _receipts(i):
+    return make_episode(f"rec-{i}", "extract customs duty receipts revenue from the bulletin")
+
+
+class TestClusterEpisodes:
+    def test_empty_input(self):
+        assert cluster_episodes([]) == []
+
+    def test_no_matching_focus(self):
+        eps = [make_episode("a", "x y z", outcome=Outcome.SUCCESS)]
+        assert cluster_episodes(eps, focus=Outcome.FAILURE) == []
+
+    def test_groups_similar_separates_dissimilar(self):
+        eps = [_deficit(i) for i in range(4)] + [_receipts(i) for i in range(4)]
+        clusters = cluster_episodes(eps, min_cluster_size=3, similarity_threshold=0.3)
+        assert len(clusters) == 2
+        sizes = sorted(c.size for c in clusters)
+        assert sizes == [4, 4]
+        # Each cluster is internally homogeneous.
+        for c in clusters:
+            prefixes = {e.episode_id.split("-")[0] for e in c.episodes}
+            assert len(prefixes) == 1
+
+    def test_min_cluster_size_filters(self):
+        eps = [_deficit(i) for i in range(4)] + [_receipts(0), _receipts(1)]
+        clusters = cluster_episodes(eps, min_cluster_size=3, similarity_threshold=0.3)
+        # only the 4-deficit cluster survives; the 2-receipt one is dropped
+        assert len(clusters) == 1
+        assert clusters[0].size == 4
+
+    def test_focus_success(self):
+        eps = [make_episode(f"s-{i}", "same winning approach reused", outcome=Outcome.SUCCESS)
+               for i in range(3)]
+        clusters = cluster_episodes(eps, focus=Outcome.SUCCESS, min_cluster_size=3)
+        assert len(clusters) == 1
+        assert clusters[0].outcome_focus is Outcome.SUCCESS
+
+    def test_max_clusters_caps(self):
+        eps = ([_deficit(i) for i in range(4)]
+               + [_receipts(i) for i in range(4)]
+               + [make_episode(f"t-{i}", "treasury bond maturity schedule listing") for i in range(4)])
+        clusters = cluster_episodes(eps, min_cluster_size=3, max_clusters=2)
+        assert len(clusters) == 2
+        # largest-first ordering preserved
+        assert clusters[0].size >= clusters[1].size
+
+    def test_cluster_properties(self):
+        eps = [_deficit(i) for i in range(3)]
+        c = cluster_episodes(eps, min_cluster_size=3)[0]
+        assert c.size == 3
+        assert c.episode_ids == ["def-0", "def-1", "def-2"]
+        assert isinstance(c.key, str) and c.key
+        assert "deficit" in c.top_terms or "budget" in c.top_terms
+
+    def test_high_threshold_yields_singletons_then_filtered(self):
+        # Dissimilar episodes + near-1.0 threshold → no merges → all singletons,
+        # then filtered out by min_cluster_size.
+        eps = [
+            make_episode("a", "alpha beta gamma delta"),
+            make_episode("b", "epsilon zeta eta theta"),
+            make_episode("c", "iota kappa lambda nu"),
+            make_episode("d", "omicron pi rho sigma"),
+        ]
+        clusters = cluster_episodes(eps, min_cluster_size=2, similarity_threshold=0.999)
+        assert clusters == []
+
+    def test_tool_names_contribute_to_similarity(self):
+        # identical tool usage + overlapping words cluster together
+        eps = [
+            make_episode("a", "read the report", tools=["grep", "bash"]),
+            make_episode("b", "read the report", tools=["grep", "bash"]),
+            make_episode("c", "read the report", tools=["grep", "bash"]),
+        ]
+        clusters = cluster_episodes(eps, min_cluster_size=3, similarity_threshold=0.3)
+        assert len(clusters) == 1
+
+    def test_task_ids_property_skips_none(self):
+        e1 = make_episode("a", "compute deficit fiscal year")
+        e2 = make_episode("b", "compute deficit fiscal year")
+        e3 = make_episode("c", "compute deficit fiscal year")
+        e1.task_id = "t1"
+        clusters = cluster_episodes([e1, e2, e3], min_cluster_size=3)
+        assert clusters[0].task_ids == ["t1"]

--- a/tests/continuous/test_collector.py
+++ b/tests/continuous/test_collector.py
@@ -1,0 +1,414 @@
+"""Tests for trace collection: ATIF parsing, readers, cursor, collector."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.continuous.collector import (
+    GooseRawReader,
+    HarborTrajectoryReader,
+    JsonlReader,
+    TraceCollector,
+    TraceCursor,
+    TraceReadError,
+    parse_atif_trajectory,
+    read_reward_file,
+)
+from src.continuous.episode import Outcome, SignalKind
+
+from .conftest import make_trial
+
+
+# ── ATIF parser ────────────────────────────────────────────────────────────────
+
+
+class TestParseAtif:
+    def test_v12_common_fields(self, atif_v12):
+        ep = parse_atif_trajectory(atif_v12, episode_id="e1")
+        assert ep.episode_id == "e1"
+        assert ep.agent_name == "goose"
+        assert ep.model_name == "openrouter/foo"
+        assert ep.prompt_tokens == 98662
+        assert ep.completion_tokens == 32888
+        assert ep.num_steps == 2
+        assert ep.cost_usd == 0.0  # v1.2 has no total_cost_usd
+        assert ep.timestamp is None  # v1.2 has no per-step timestamp
+        assert ep.extra["schema_version"] == "ATIF-v1.2"
+
+    def test_v12_links_tool_call_to_observation(self, atif_v12):
+        ep = parse_atif_trajectory(atif_v12, episode_id="e1")
+        first = ep.actions[0]
+        assert first.tool_calls[0].function_name == "analyze"
+        assert first.tool_calls[0].observation == "0 files found"
+
+    def test_task_text_from_first_reasoning(self, atif_v12):
+        ep = parse_atif_trajectory(atif_v12, episode_id="e1")
+        assert ep.task_text.startswith("I need to find the average")
+
+    def test_final_output_skips_tool_call_placeholder(self, atif_v12):
+        # last step message is "[tool call]" → falls back to its reasoning
+        ep = parse_atif_trajectory(atif_v12, episode_id="e1")
+        assert ep.final_output == "The answer is 12345."
+
+    def test_v16_timestamp_and_cost(self, atif_v16):
+        ep = parse_atif_trajectory(atif_v16, episode_id="e2")
+        assert ep.agent_name == "opencode"
+        assert ep.cost_usd == 0.154
+        assert ep.timestamp == "2026-05-06T13:41:00Z"  # last step with a timestamp
+        assert ep.extra["schema_version"] == "ATIF-v1.6"
+
+    def test_v16_multiple_tool_calls_each_linked(self, atif_v16):
+        ep = parse_atif_trajectory(atif_v16, episode_id="e2")
+        tcs = ep.actions[0].tool_calls
+        assert [t.function_name for t in tcs] == ["glob", "bash"]
+        assert tcs[0].observation == "/app/hand1.json"
+        assert tcs[1].observation == "total 20"
+
+    def test_handles_empty_and_garbage(self):
+        ep = parse_atif_trajectory({}, episode_id="e")
+        assert ep.actions == []
+        assert ep.num_steps == 0
+        # Non-list steps / non-dict agent must not crash.
+        ep2 = parse_atif_trajectory({"steps": "nope", "agent": "nope"}, episode_id="e")
+        assert ep2.actions == []
+        assert ep2.agent_name is None
+
+    def test_num_steps_falls_back_to_len(self):
+        payload = {"steps": [{"source": "agent", "message": "a"}], "final_metrics": {}}
+        ep = parse_atif_trajectory(payload, episode_id="e")
+        assert ep.num_steps == 1
+
+    def test_non_numeric_metrics_coerce_to_zero(self):
+        payload = {
+            "steps": [{"source": "agent", "message": "a"}],
+            "final_metrics": {
+                "total_prompt_tokens": "oops",
+                "total_cost_usd": None,
+            },
+        }
+        ep = parse_atif_trajectory(payload, episode_id="e")
+        assert ep.prompt_tokens == 0
+        assert ep.cost_usd == 0.0
+
+    def test_task_text_falls_back_to_message_when_no_reasoning(self):
+        payload = {"steps": [{"source": "agent", "message": "Just do it", "reasoning_content": ""}]}
+        ep = parse_atif_trajectory(payload, episode_id="e")
+        assert ep.task_text == "Just do it"
+
+    def test_task_text_empty_when_only_placeholder(self):
+        payload = {"steps": [{"source": "agent", "message": "[tool call]"}]}
+        ep = parse_atif_trajectory(payload, episode_id="e")
+        assert ep.task_text == ""
+
+    def test_tool_calls_tolerate_bad_shapes(self):
+        payload = {
+            "steps": [{
+                "source": "agent",
+                "tool_calls": ["not-a-dict", {"function_name": "f", "arguments": "scalar"}],
+                "observation": "not-a-dict",
+            }]
+        }
+        ep = parse_atif_trajectory(payload, episode_id="e")
+        # the string entry is dropped; the dict entry survives with wrapped args
+        assert len(ep.actions[0].tool_calls) == 1
+        assert ep.actions[0].tool_calls[0].arguments == {"value": "scalar"}
+
+    def test_non_agent_steps_excluded_from_final_output(self):
+        payload = {"steps": [
+            {"source": "agent", "message": "hello"},
+            {"source": "environment", "message": "env noise"},
+        ]}
+        ep = parse_atif_trajectory(payload, episode_id="e")
+        assert ep.final_output == "hello"
+
+
+# ── read_reward_file ─────────────────────────────────────────────────────────
+
+
+class TestReadRewardFile:
+    def test_reads_value(self, tmp_path):
+        (tmp_path / "verifier").mkdir()
+        (tmp_path / "verifier" / "reward.txt").write_text("0.75\n")
+        assert read_reward_file(tmp_path) == 0.75
+
+    def test_missing_returns_none(self, tmp_path):
+        assert read_reward_file(tmp_path) is None
+
+    def test_empty_returns_none(self, tmp_path):
+        (tmp_path / "verifier").mkdir()
+        (tmp_path / "verifier" / "reward.txt").write_text("   ")
+        assert read_reward_file(tmp_path) is None
+
+    def test_unparseable_returns_none(self, tmp_path):
+        (tmp_path / "verifier").mkdir()
+        (tmp_path / "verifier" / "reward.txt").write_text("not-a-number")
+        assert read_reward_file(tmp_path) is None
+
+
+# ── HarborTrajectoryReader ─────────────────────────────────────────────────────
+
+
+class TestHarborTrajectoryReader:
+    def test_discovers_and_labels_all_trials(self, jobs_root):
+        eps = list(HarborTrajectoryReader(jobs_root).read_all())
+        assert len(eps) == 3
+        by_id = {e.task_id: e for e in eps}
+        assert by_id["bench/task-pass"].outcome is Outcome.SUCCESS
+        assert by_id["bench/task-fail"].outcome is Outcome.FAILURE
+        # partial (0.5) is a failure under the default strict threshold
+        assert by_id["bench/task-partial"].outcome is Outcome.FAILURE
+        assert by_id["bench/task-partial"].signal.value == 0.5
+
+    def test_episode_id_is_trial_dir_name(self, jobs_root):
+        eps = {e.episode_id for e in HarborTrajectoryReader(jobs_root).read_all()}
+        assert "task-pass__AAA" in eps
+
+    def test_reward_signal_is_verifier_kind(self, jobs_root):
+        ep = next(HarborTrajectoryReader(jobs_root).read_all())
+        assert ep.signal.kind is SignalKind.VERIFIER_REWARD
+        assert ep.signal.confidence == 1.0
+
+    def test_no_reward_yields_unknown(self, tmp_path):
+        root = tmp_path / "jobs"
+        make_trial(root, "t__X", reward=None, task_name="b/t")
+        ep = next(HarborTrajectoryReader(root).read_all())
+        assert ep.outcome is Outcome.UNKNOWN
+        assert ep.signal.kind is SignalKind.NONE
+
+    def test_custom_success_threshold(self, jobs_root):
+        eps = {e.task_id: e for e in HarborTrajectoryReader(jobs_root, success_threshold=0.5).read_all()}
+        assert eps["bench/task-partial"].outcome is Outcome.SUCCESS
+
+    def test_missing_root_yields_nothing(self, tmp_path):
+        assert list(HarborTrajectoryReader(tmp_path / "nope").read_all()) == []
+
+    def test_malformed_trajectory_is_skipped(self, tmp_path):
+        root = tmp_path / "jobs"
+        make_trial(root, "good__A", reward="1", task_name="b/good")
+        bad = root / "job-1" / "bad__B" / "agent"
+        bad.mkdir(parents=True)
+        (bad / "trajectory.json").write_text("{not valid json")
+        eps = list(HarborTrajectoryReader(root).read_all())
+        assert {e.episode_id for e in eps} == {"good__A"}
+
+    def test_parse_trial_raises_on_garbage(self, tmp_path):
+        agent = tmp_path / "t" / "agent"
+        agent.mkdir(parents=True)
+        (agent / "trajectory.json").write_text("[]")  # JSON, but not an object
+        with pytest.raises(TraceReadError):
+            HarborTrajectoryReader(tmp_path).parse_trial(tmp_path / "t")
+
+    def test_task_id_from_result_task_id_path(self, tmp_path):
+        trial = make_trial(tmp_path / "jobs", "t__X", reward="1", task_name=None)
+        (trial / "result.json").write_text(
+            json.dumps({"task_id": {"path": "/data/datasets/officeqa/officeqa-uid0132"}})
+        )
+        ep = HarborTrajectoryReader(tmp_path / "jobs").parse_trial(trial)
+        assert ep.task_id == "officeqa-uid0132"
+
+    def test_task_id_none_when_no_result(self, tmp_path):
+        trial = make_trial(tmp_path / "jobs", "t__X", reward="1", task_name=None)
+        ep = HarborTrajectoryReader(tmp_path / "jobs").parse_trial(trial)
+        assert ep.task_id is None
+
+    def test_corrupt_result_json_tolerated(self, tmp_path):
+        trial = make_trial(tmp_path / "jobs", "t__X", reward="1", task_name=None)
+        (trial / "result.json").write_text("{bad json")
+        ep = HarborTrajectoryReader(tmp_path / "jobs").parse_trial(trial)
+        assert ep.task_id is None  # falls back gracefully
+
+
+# ── GooseRawReader ─────────────────────────────────────────────────────────────
+
+
+class TestGooseRawReader:
+    def test_reconstructs_messages(self, tmp_path):
+        root = tmp_path / "jobs"
+        make_trial(root, "t__X", reward="1", task_name="b/t", goose_log=True)
+        eps = list(GooseRawReader(root).read_all())
+        assert len(eps) == 1
+        ep = eps[0]
+        assert ep.source == "goose"
+        assert ep.outcome is Outcome.SUCCESS  # reward picked up from sibling verifier
+        # m1 accumulated thinking "Let me think." and text "Answer: 42"
+        first = ep.actions[0]
+        assert first.reasoning == "Let me think."
+        assert first.message == "Answer: 42"
+        assert ep.final_output == "Answer: 42"
+        # m2 carried a tool request
+        assert ep.actions[1].tool_calls[0].function_name == "bash"
+
+    def test_skips_malformed_lines(self, tmp_path):
+        root = tmp_path / "jobs"
+        trial = make_trial(root, "t__X", reward=None, goose_log=True)
+        log = trial / "agent" / "goose.txt"
+        log.write_text(log.read_text() + "\nnot json\n{}\n")
+        eps = list(GooseRawReader(root).read_all())
+        assert len(eps) == 1  # garbage lines ignored, episode still built
+
+    def test_empty_log_skipped(self, tmp_path):
+        root = tmp_path / "jobs"
+        trial = make_trial(root, "t__X", reward=None, goose_log=True)
+        (trial / "agent" / "goose.txt").write_text("Loading recipe\n")  # no messages
+        assert list(GooseRawReader(root).read_all()) == []
+
+    def test_missing_root_yields_nothing(self, tmp_path):
+        assert list(GooseRawReader(tmp_path / "nope").read_all()) == []
+
+
+# ── JsonlReader ────────────────────────────────────────────────────────────────
+
+
+class TestJsonlReader:
+    def _write(self, tmp_path, records) -> Path:
+        p = tmp_path / "traces.jsonl"
+        p.write_text("\n".join(json.dumps(r) for r in records))
+        return p
+
+    def test_reward_record(self, tmp_path):
+        p = self._write(tmp_path, [{"task": "do x", "output": "y", "reward": 1.0, "episode_id": "z"}])
+        ep = next(JsonlReader(p).read_all())
+        assert ep.episode_id == "z"
+        assert ep.task_text == "do x"
+        assert ep.final_output == "y"
+        assert ep.outcome is Outcome.SUCCESS
+        assert ep.signal.kind is SignalKind.VERIFIER_REWARD
+
+    def test_explicit_outcome_without_reward(self, tmp_path):
+        p = self._write(tmp_path, [{"task": "t", "outcome": "success"}])
+        ep = next(JsonlReader(p).read_all())
+        assert ep.outcome is Outcome.SUCCESS
+        assert ep.signal.confidence == 0.5  # implicit, not ground truth
+
+    def test_no_signal_when_neither(self, tmp_path):
+        p = self._write(tmp_path, [{"task": "t"}])
+        ep = next(JsonlReader(p).read_all())
+        assert ep.outcome is Outcome.UNKNOWN
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [("fail", Outcome.FAILURE), ("passed", Outcome.SUCCESS),
+         ("0", Outcome.FAILURE), ("weird", Outcome.UNKNOWN)],
+    )
+    def test_explicit_outcome_strings(self, tmp_path, raw, expected):
+        p = self._write(tmp_path, [{"task": "t", "outcome": raw}])
+        ep = next(JsonlReader(p).read_all())
+        assert ep.outcome is expected
+
+    def test_parses_steps_and_skills(self, tmp_path):
+        p = self._write(tmp_path, [{
+            "task": "t",
+            "skills_active": ["s1", "s2"],
+            "steps": [{"source": "agent", "message": "m", "reasoning": "r"}],
+        }])
+        ep = next(JsonlReader(p).read_all())
+        assert ep.skills_active == ["s1", "s2"]
+        assert ep.actions[0].reasoning == "r"
+        assert ep.num_steps == 1
+
+    def test_missing_task_skipped(self, tmp_path):
+        p = self._write(tmp_path, [{"output": "no task"}, {"task": "ok"}])
+        eps = list(JsonlReader(p).read_all())
+        assert len(eps) == 1
+        assert eps[0].task_text == "ok"
+
+    def test_blank_and_nonjson_lines_skipped(self, tmp_path):
+        p = tmp_path / "t.jsonl"
+        p.write_text('\n  \nnot json\n{"task": "ok"}\n[1,2,3]\n')
+        eps = list(JsonlReader(p).read_all())
+        assert len(eps) == 1
+
+    def test_derived_episode_id_is_stable(self, tmp_path):
+        rec = [{"task": "same"}]
+        p1 = self._write(tmp_path, rec)
+        a = next(JsonlReader(p1).read_all())
+        b = next(JsonlReader(p1).read_all())
+        assert a.episode_id == b.episode_id  # deterministic from path+index+task
+
+    def test_missing_file_yields_nothing(self, tmp_path):
+        assert list(JsonlReader(tmp_path / "nope.jsonl").read_all()) == []
+
+    def test_custom_source_tag(self, tmp_path):
+        p = self._write(tmp_path, [{"task": "t"}])
+        ep = next(JsonlReader(p, source="hook").read_all())
+        assert ep.source == "hook"
+
+
+# ── TraceCursor ────────────────────────────────────────────────────────────────
+
+
+class TestTraceCursor:
+    def test_starts_empty(self, tmp_path):
+        cur = TraceCursor(tmp_path / "cursor.json")
+        assert len(cur) == 0
+        assert not cur.seen("x")
+
+    def test_mark_save_reload(self, tmp_path):
+        path = tmp_path / "sub" / "cursor.json"
+        cur = TraceCursor(path)
+        cur.mark("a")
+        cur.mark("b")
+        cur.save()
+        assert path.is_file()
+        reloaded = TraceCursor(path)
+        assert reloaded.seen("a") and reloaded.seen("b")
+        assert len(reloaded) == 2
+
+    def test_corrupt_file_treated_as_empty(self, tmp_path):
+        path = tmp_path / "cursor.json"
+        path.write_text("{not json")
+        cur = TraceCursor(path)
+        assert len(cur) == 0
+
+    def test_non_dict_payload_treated_as_empty(self, tmp_path):
+        path = tmp_path / "cursor.json"
+        path.write_text("[1,2,3]")
+        assert len(TraceCursor(path)) == 0
+
+
+# ── TraceCollector ─────────────────────────────────────────────────────────────
+
+
+class TestTraceCollector:
+    def test_collects_all_with_no_cursor(self, jobs_root):
+        col = TraceCollector([HarborTrajectoryReader(jobs_root)])
+        assert len(col.collect()) == 3
+
+    def test_reader_priority_dedup(self, tmp_path):
+        # One trial with BOTH an ATIF trajectory and a goose log → same episode_id.
+        root = tmp_path / "jobs"
+        make_trial(root, "t__X", reward="1", task_name="b/t", goose_log=True)
+        col = TraceCollector([HarborTrajectoryReader(root), GooseRawReader(root)])
+        eps = col.collect()
+        assert len(eps) == 1
+        assert eps[0].source == "harbor"  # earlier reader wins
+
+    def test_cursor_dedup_across_batches(self, jobs_root, tmp_path):
+        cur = TraceCursor(tmp_path / "cursor.json")
+        col = TraceCollector([HarborTrajectoryReader(jobs_root)], cursor=cur)
+        assert len(col.collect()) == 3
+        assert len(col.collect()) == 0  # all watermarked
+        assert len(cur) == 3
+
+    def test_advance_false_does_not_persist(self, jobs_root, tmp_path):
+        path = tmp_path / "cursor.json"
+        cur = TraceCursor(path)
+        col = TraceCollector([HarborTrajectoryReader(jobs_root)], cursor=cur)
+        col.collect(advance=False)
+        assert len(cur) == 0
+        assert not path.is_file()
+
+    def test_limit_caps_new_episodes(self, jobs_root):
+        col = TraceCollector([HarborTrajectoryReader(jobs_root)])
+        assert len(col.collect(limit=2)) == 2
+
+    def test_limit_across_readers(self, tmp_path):
+        root_a = tmp_path / "a"
+        root_b = tmp_path / "b"
+        make_trial(root_a, "a1__X", reward="1", task_name="x/a1")
+        make_trial(root_b, "b1__Y", reward="1", task_name="x/b1", goose_log=True)
+        col = TraceCollector([HarborTrajectoryReader(root_a), GooseRawReader(root_b)])
+        assert len(col.collect(limit=1)) == 1

--- a/tests/continuous/test_continuous_cli.py
+++ b/tests/continuous/test_continuous_cli.py
@@ -15,6 +15,7 @@ from src.cli.commands.candidates import candidates_cmd
 from src.cli.commands.graduate import graduate_cmd, reject_cmd
 from src.cli.commands.harvest import harvest_cmd
 from src.cli.commands.library import library_cmd
+from src.cli.commands.watch import watch_cmd
 from src.continuous.candidates import Candidate, CandidateStore
 
 from .conftest import make_trial
@@ -193,3 +194,20 @@ class TestGraduateCli:
         cfg = _project(tmp_path)
         result = CliRunner().invoke(reject_cmd, ["--config", str(cfg), "nope"])
         assert result.exit_code == 1
+
+
+class TestWatchCli:
+    def test_once_review_no_traces(self, tmp_path):
+        # review mode + empty traces dir → one tick, 0 episodes, no LLM/git needed.
+        cfg = _project(tmp_path)
+        (tmp_path / ".evoskill" / "harbor_jobs").mkdir(parents=True)
+        result = CliRunner().invoke(watch_cmd, ["--config", str(cfg), "--once"])
+        assert result.exit_code == 0, result.output
+        assert "Ran 1 tick(s)" in result.output
+        assert "0 episodes" in result.output
+
+    def test_no_usable_sources_errors(self, tmp_path):
+        cfg = _project(tmp_path, '\n[continuous]\ntrace_sources = ["jsonl"]\n')
+        result = CliRunner().invoke(watch_cmd, ["--config", str(cfg), "--once"])
+        assert result.exit_code == 1
+        assert "no usable trace sources" in result.output

--- a/tests/continuous/test_continuous_cli.py
+++ b/tests/continuous/test_continuous_cli.py
@@ -13,9 +13,16 @@ from click.testing import CliRunner
 
 from src.cli.commands.candidates import candidates_cmd
 from src.cli.commands.harvest import harvest_cmd
+from src.cli.commands.library import library_cmd
 from src.continuous.candidates import Candidate, CandidateStore
 
 from .conftest import make_trial
+
+
+def _write_skill(skills_dir: Path, name: str, description: str) -> None:
+    d = skills_dir / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: {description}\n---\n\nbody")
 
 
 def _project(tmp_path: Path, continuous_toml: str = "") -> Path:
@@ -96,3 +103,50 @@ class TestCandidatesCli:
         assert "b" in result.output
         # 'a' (pending) should be filtered out of the table rows
         assert "1 candidate(s)" in result.output
+
+
+class TestLibraryCli:
+    # Force lexical similarity so tests never hit a real embedding API.
+    # Lower dedupe threshold to match lexical cosine scores (~0.78 for paraphrases).
+    LEXICAL = '\n[continuous.lifecycle]\nsimilarity_backend = "lexical"\ndedupe_similarity = 0.6\n'
+
+    def test_empty(self, tmp_path):
+        cfg = _project(tmp_path)
+        result = CliRunner().invoke(library_cmd, ["--config", str(cfg)])
+        assert result.exit_code == 0
+        assert "No skills yet" in result.output
+
+    def test_list_with_stats(self, tmp_path):
+        cfg = _project(tmp_path)
+        _write_skill(tmp_path / ".claude" / "skills", "preserve-units", "include units")
+        result = CliRunner().invoke(library_cmd, ["--config", str(cfg)])
+        assert result.exit_code == 0
+        assert "preserve-units" in result.output
+        assert "1 skill(s)" in result.output
+
+    def test_duplicates(self, tmp_path):
+        cfg = _project(tmp_path, self.LEXICAL)
+        sd = tmp_path / ".claude" / "skills"
+        _write_skill(sd, "preserve-units", "always include measurement units in answers")
+        _write_skill(sd, "keep-units", "always include measurement units in answers please")
+        _write_skill(sd, "read-tables", "extract figures from financial tables")
+        result = CliRunner().invoke(library_cmd, ["--config", str(cfg), "--duplicates"])
+        assert result.exit_code == 0
+        # the two near-identical unit skills should be flagged similar
+        assert "preserve-units" in result.output and "keep-units" in result.output
+
+    def test_select(self, tmp_path):
+        cfg = _project(tmp_path, self.LEXICAL)
+        sd = tmp_path / ".claude" / "skills"
+        _write_skill(sd, "preserve-units", "include measurement units in numeric answers")
+        _write_skill(sd, "read-tables", "extract figures from financial tables")
+        result = CliRunner().invoke(
+            library_cmd, ["--config", str(cfg), "--select", "what units for this revenue value"])
+        assert result.exit_code == 0
+        assert "preserve-units" in result.output
+
+    def test_deprecated_empty(self, tmp_path):
+        cfg = _project(tmp_path)
+        result = CliRunner().invoke(library_cmd, ["--config", str(cfg), "--deprecated"])
+        assert result.exit_code == 0
+        assert "No deprecated skills" in result.output

--- a/tests/continuous/test_continuous_cli.py
+++ b/tests/continuous/test_continuous_cli.py
@@ -1,0 +1,98 @@
+"""CLI tests for `evoskill harvest` (dry-run) and `evoskill candidates`.
+
+Full harvest (LLM distillation) is covered by test_harvest.py against a fake
+distiller; here we exercise the click wiring, argument resolution, and the
+no-LLM paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from src.cli.commands.candidates import candidates_cmd
+from src.cli.commands.harvest import harvest_cmd
+from src.continuous.candidates import Candidate, CandidateStore
+
+from .conftest import make_trial
+
+
+def _project(tmp_path: Path, continuous_toml: str = "") -> Path:
+    evoskill = tmp_path / ".evoskill"
+    evoskill.mkdir()
+    (evoskill / "config.toml").write_text('[harness]\nname = "claude"\n' + continuous_toml)
+    return evoskill / "config.toml"
+
+
+class TestHarvestCli:
+    def test_dry_run_collects_and_clusters(self, tmp_path):
+        cfg = _project(tmp_path)
+        traces = tmp_path / "traces"
+        # three failing trials with identical task text → one cluster
+        for i in range(3):
+            make_trial(traces, f"t{i}__X{i}", reward="0", task_name=f"bench/t{i}")
+        result = CliRunner().invoke(harvest_cmd, [
+            "--config", str(cfg), "--traces", str(traces),
+            "--source", "harbor", "--dry-run", "--min-cluster-size", "1",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "Collected 3 episode(s)" in result.output
+        assert "no candidates written" in result.output
+
+    def test_no_usable_sources_errors(self, tmp_path):
+        cfg = _project(tmp_path)
+        # jsonl source but no jsonl_path configured → build_readers yields nothing
+        result = CliRunner().invoke(harvest_cmd, ["--config", str(cfg), "--source", "jsonl"])
+        assert result.exit_code == 1
+        assert "no usable trace sources" in result.output
+
+
+class TestCandidatesCli:
+    def test_empty(self, tmp_path):
+        cfg = _project(tmp_path)
+        result = CliRunner().invoke(candidates_cmd, ["--config", str(cfg)])
+        assert result.exit_code == 0
+        assert "No candidates yet" in result.output
+
+    def test_list_and_show(self, tmp_path):
+        cfg = _project(tmp_path)
+        from src.cli.config import load_config
+        store = CandidateStore(load_config(config_path=cfg).continuous_candidates_dir)
+        store.save(Candidate(
+            candidate_id="my-skill-abc",
+            skill_name="my-skill",
+            skill_markdown="---\nname: my-skill\ndescription: d\n---\nthe body rule",
+            target_pattern="recurring thing",
+            episode_ids=["e1", "e2", "e3"],
+            cluster_size=3,
+        ))
+
+        listing = CliRunner().invoke(candidates_cmd, ["--config", str(cfg)])
+        assert listing.exit_code == 0
+        assert "my-skill-abc" in listing.output
+        assert "1 candidate(s)" in listing.output
+
+        shown = CliRunner().invoke(candidates_cmd, ["--config", str(cfg), "--show", "my-skill-abc"])
+        assert shown.exit_code == 0
+        assert "the body rule" in shown.output
+        assert "recurring thing" in shown.output  # full pattern, not truncated in --show
+
+    def test_show_missing(self, tmp_path):
+        cfg = _project(tmp_path)
+        result = CliRunner().invoke(candidates_cmd, ["--config", str(cfg), "--show", "nope"])
+        assert result.exit_code == 1
+        assert "no candidate" in result.output
+
+    def test_status_filter(self, tmp_path):
+        cfg = _project(tmp_path)
+        from src.cli.config import load_config
+        store = CandidateStore(load_config(config_path=cfg).continuous_candidates_dir)
+        store.save(Candidate(candidate_id="a", skill_name="a", skill_markdown="x", episode_ids=["e"]))
+        store.save(Candidate(candidate_id="b", skill_name="b", skill_markdown="y",
+                             episode_ids=["f"], status="graduated"))
+        result = CliRunner().invoke(candidates_cmd, ["--config", str(cfg), "--status", "graduated"])
+        assert result.exit_code == 0
+        assert "b" in result.output
+        # 'a' (pending) should be filtered out of the table rows
+        assert "1 candidate(s)" in result.output

--- a/tests/continuous/test_continuous_cli.py
+++ b/tests/continuous/test_continuous_cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from src.cli.commands.candidates import candidates_cmd
+from src.cli.commands.graduate import graduate_cmd, reject_cmd
 from src.cli.commands.harvest import harvest_cmd
 from src.cli.commands.library import library_cmd
 from src.continuous.candidates import Candidate, CandidateStore
@@ -150,3 +151,45 @@ class TestLibraryCli:
         result = CliRunner().invoke(library_cmd, ["--config", str(cfg), "--deprecated"])
         assert result.exit_code == 0
         assert "No deprecated skills" in result.output
+
+
+class TestGraduateCli:
+    def _candidate(self):
+        return Candidate(
+            candidate_id="units-abc", skill_name="preserve-units",
+            skill_markdown="---\nname: preserve-units\ndescription: d\n---\nrule",
+            episode_ids=["e1"], cluster_size=1,
+        )
+
+    def test_force_no_branch_installs(self, tmp_path):
+        cfg = _project(tmp_path)
+        from src.cli.config import load_config
+        loaded = load_config(config_path=cfg)
+        CandidateStore(loaded.continuous_candidates_dir).save(self._candidate())
+        # --force skips the gate (no LLM); --no-branch skips git
+        result = CliRunner().invoke(
+            graduate_cmd, ["--config", str(cfg), "--force", "--no-branch", "units-abc"])
+        assert result.exit_code == 0, result.output
+        assert "Graduated" in result.output
+        assert (loaded.skills_dir / "preserve-units" / "SKILL.md").is_file()
+        assert CandidateStore(loaded.continuous_candidates_dir).get("units-abc").status == "graduated"
+
+    def test_graduate_missing_candidate(self, tmp_path):
+        cfg = _project(tmp_path)
+        result = CliRunner().invoke(graduate_cmd, ["--config", str(cfg), "--force", "nope"])
+        assert result.exit_code == 1
+        assert "no candidate" in result.output
+
+    def test_reject(self, tmp_path):
+        cfg = _project(tmp_path)
+        from src.cli.config import load_config
+        store = CandidateStore(load_config(config_path=cfg).continuous_candidates_dir)
+        store.save(self._candidate())
+        result = CliRunner().invoke(reject_cmd, ["--config", str(cfg), "units-abc"])
+        assert result.exit_code == 0
+        assert store.get("units-abc").status == "rejected"
+
+    def test_reject_missing(self, tmp_path):
+        cfg = _project(tmp_path)
+        result = CliRunner().invoke(reject_cmd, ["--config", str(cfg), "nope"])
+        assert result.exit_code == 1

--- a/tests/continuous/test_continuous_config.py
+++ b/tests/continuous/test_continuous_config.py
@@ -96,6 +96,26 @@ class TestGraduationConfig:
         assert cfg.continuous.shadow_eval_size == 25
 
 
+class TestWatchConfig:
+    def test_defaults(self, tmp_path):
+        cfg = load_config(config_path=_write_project(tmp_path))
+        assert cfg.continuous.poll_interval_sec == 600
+        assert cfg.continuous.cost_ceiling_usd_per_tick == 0.0
+        assert cfg.continuous.auto_deprecate is False
+
+    def test_overrides(self, tmp_path):
+        toml = (
+            "\n[continuous]\n"
+            "poll_interval_sec = 120\n"
+            "cost_ceiling_usd_per_tick = 2.5\n"
+            "auto_deprecate = true\n"
+        )
+        cfg = load_config(config_path=_write_project(tmp_path, toml))
+        assert cfg.continuous.poll_interval_sec == 120
+        assert cfg.continuous.cost_ceiling_usd_per_tick == 2.5
+        assert cfg.continuous.auto_deprecate is True
+
+
 class TestDerivedPaths:
     def test_traces_root_defaults_to_harbor_jobs(self, tmp_path):
         cfg = load_config(config_path=_write_project(tmp_path))

--- a/tests/continuous/test_continuous_config.py
+++ b/tests/continuous/test_continuous_config.py
@@ -1,0 +1,74 @@
+"""Tests for the [continuous] config section and derived paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.cli.config import ContinuousConfig, load_config
+
+
+def _write_project(tmp_path: Path, continuous_toml: str = "") -> Path:
+    evoskill = tmp_path / ".evoskill"
+    evoskill.mkdir()
+    (evoskill / "config.toml").write_text('[harness]\nname = "claude"\n' + continuous_toml)
+    return evoskill / "config.toml"
+
+
+class TestContinuousConfigDefaults:
+    def test_defaults(self):
+        c = ContinuousConfig()
+        assert c.enabled is False
+        assert c.trace_sources == ["harbor"]
+        assert c.focus == "failure"
+        assert c.min_cluster_size == 3
+        assert c.success_threshold == 1.0
+
+    def test_absent_section_uses_defaults(self, tmp_path):
+        cfg = load_config(config_path=_write_project(tmp_path))
+        assert cfg.continuous.enabled is False
+        assert cfg.continuous.trace_sources == ["harbor"]
+
+
+class TestContinuousConfigParsing:
+    def test_overrides_parsed(self, tmp_path):
+        toml = (
+            "\n[continuous]\n"
+            "enabled = true\n"
+            'trace_sources = ["harbor", "jsonl"]\n'
+            "harvest_window = 50\n"
+            "min_cluster_size = 5\n"
+            "similarity_threshold = 0.5\n"
+            'focus = "both"\n'
+        )
+        cfg = load_config(config_path=_write_project(tmp_path, toml))
+        assert cfg.continuous.enabled is True
+        assert cfg.continuous.trace_sources == ["harbor", "jsonl"]
+        assert cfg.continuous.harvest_window == 50
+        assert cfg.continuous.min_cluster_size == 5
+        assert cfg.continuous.similarity_threshold == 0.5
+        assert cfg.continuous.focus == "both"
+
+
+class TestDerivedPaths:
+    def test_traces_root_defaults_to_harbor_jobs(self, tmp_path):
+        cfg = load_config(config_path=_write_project(tmp_path))
+        assert cfg.continuous_traces_root == tmp_path / ".evoskill" / "harbor_jobs"
+
+    def test_traces_root_relative_override(self, tmp_path):
+        cfg = load_config(config_path=_write_project(tmp_path, '\n[continuous]\ntraces_root = "mytraces"\n'))
+        assert cfg.continuous_traces_root == tmp_path / "mytraces"
+
+    def test_traces_root_absolute_override(self, tmp_path):
+        abs_path = tmp_path / "abs" / "traces"
+        cfg = load_config(config_path=_write_project(
+            tmp_path, f'\n[continuous]\ntraces_root = "{abs_path}"\n'))
+        assert cfg.continuous_traces_root == abs_path
+
+    def test_candidates_dir(self, tmp_path):
+        cfg = load_config(config_path=_write_project(tmp_path))
+        assert cfg.continuous_candidates_dir == tmp_path / ".evoskill" / "continuous" / "candidates"
+
+    def test_harbor_jobs_dir_respects_config(self, tmp_path):
+        cfg = load_config(config_path=_write_project(tmp_path))
+        # default
+        assert cfg.harbor_jobs_dir == tmp_path / ".evoskill" / "harbor_jobs"

--- a/tests/continuous/test_continuous_config.py
+++ b/tests/continuous/test_continuous_config.py
@@ -49,6 +49,32 @@ class TestContinuousConfigParsing:
         assert cfg.continuous.focus == "both"
 
 
+class TestLifecycleConfig:
+    def test_defaults(self, tmp_path):
+        cfg = load_config(config_path=_write_project(tmp_path))
+        lc = cfg.continuous.lifecycle
+        assert lc.similarity_backend == "embedding"
+        assert lc.embedding_provider == "openai"
+        assert lc.embedding_model == "text-embedding-3-small"
+        assert lc.dedupe_similarity == 0.88
+        assert lc.deprecation_strikes == 3
+        assert lc.retrieval_top_k == 6
+
+    def test_nested_section_parsed(self, tmp_path):
+        toml = (
+            "\n[continuous]\nenabled = true\n"
+            "\n[continuous.lifecycle]\n"
+            'similarity_backend = "lexical"\n'
+            "dedupe_similarity = 0.75\n"
+            "retrieval_top_k = 10\n"
+        )
+        cfg = load_config(config_path=_write_project(tmp_path, toml))
+        assert cfg.continuous.enabled is True
+        assert cfg.continuous.lifecycle.similarity_backend == "lexical"
+        assert cfg.continuous.lifecycle.dedupe_similarity == 0.75
+        assert cfg.continuous.lifecycle.retrieval_top_k == 10
+
+
 class TestDerivedPaths:
     def test_traces_root_defaults_to_harbor_jobs(self, tmp_path):
         cfg = load_config(config_path=_write_project(tmp_path))

--- a/tests/continuous/test_continuous_config.py
+++ b/tests/continuous/test_continuous_config.py
@@ -75,6 +75,27 @@ class TestLifecycleConfig:
         assert cfg.continuous.lifecycle.retrieval_top_k == 10
 
 
+class TestGraduationConfig:
+    def test_defaults(self, tmp_path):
+        cfg = load_config(config_path=_write_project(tmp_path))
+        assert cfg.continuous.graduation_mode == "review"
+        assert cfg.continuous.graduation_threshold == 0.6
+        assert cfg.continuous.shadow_eval_size == 10
+        assert cfg.continuous.max_graduations_per_window == 2
+
+    def test_overrides(self, tmp_path):
+        toml = (
+            "\n[continuous]\n"
+            'graduation_mode = "auto"\n'
+            "graduation_threshold = 0.8\n"
+            "shadow_eval_size = 25\n"
+        )
+        cfg = load_config(config_path=_write_project(tmp_path, toml))
+        assert cfg.continuous.graduation_mode == "auto"
+        assert cfg.continuous.graduation_threshold == 0.8
+        assert cfg.continuous.shadow_eval_size == 25
+
+
 class TestDerivedPaths:
     def test_traces_root_defaults_to_harbor_jobs(self, tmp_path):
         cfg = load_config(config_path=_write_project(tmp_path))

--- a/tests/continuous/test_episode.py
+++ b/tests/continuous/test_episode.py
@@ -1,0 +1,73 @@
+"""Tests for the continuous-evolution episode model."""
+
+from __future__ import annotations
+
+from src.continuous.episode import (
+    ActionStep,
+    Outcome,
+    OutcomeSignal,
+    SignalKind,
+    TaskEpisode,
+    ToolCall,
+)
+
+
+class TestTaskEpisode:
+    def test_minimal_episode_defaults(self):
+        ep = TaskEpisode(episode_id="e1", source="harbor")
+        assert ep.episode_id == "e1"
+        assert ep.source == "harbor"
+        assert ep.task_text == ""
+        assert ep.actions == []
+        assert ep.outcome is Outcome.UNKNOWN
+        assert ep.signal is None
+        assert ep.skills_active == []
+        assert ep.cost_usd == 0.0
+        assert ep.is_success is False
+        assert ep.is_failure is False
+
+    def test_success_and_failure_helpers(self):
+        ok = TaskEpisode(episode_id="e", source="s", outcome=Outcome.SUCCESS)
+        bad = TaskEpisode(episode_id="e", source="s", outcome=Outcome.FAILURE)
+        assert ok.is_success and not ok.is_failure
+        assert bad.is_failure and not bad.is_success
+
+    def test_round_trips_through_json(self):
+        ep = TaskEpisode(
+            episode_id="e1",
+            source="harbor",
+            task_text="do thing",
+            actions=[
+                ActionStep(
+                    step_id=1,
+                    message="m",
+                    reasoning="r",
+                    tool_calls=[ToolCall(tool_call_id="c1", function_name="bash")],
+                )
+            ],
+            signal=OutcomeSignal(kind=SignalKind.VERIFIER_REWARD, outcome=Outcome.SUCCESS, value=1.0),
+            outcome=Outcome.SUCCESS,
+        )
+        restored = TaskEpisode.model_validate_json(ep.model_dump_json())
+        assert restored == ep
+        assert restored.actions[0].tool_calls[0].function_name == "bash"
+        assert restored.signal.kind is SignalKind.VERIFIER_REWARD
+
+
+class TestActionStep:
+    def test_defaults(self):
+        step = ActionStep()
+        assert step.source == "agent"
+        assert step.message == ""
+        assert step.tool_calls == []
+
+    def test_preserves_non_agent_source(self):
+        step = ActionStep(source="environment", message="observation")
+        assert step.source == "environment"
+
+
+class TestToolCall:
+    def test_observation_optional(self):
+        tc = ToolCall(function_name="bash", arguments={"command": "ls"})
+        assert tc.observation is None
+        assert tc.arguments["command"] == "ls"

--- a/tests/continuous/test_gate.py
+++ b/tests/continuous/test_gate.py
@@ -1,0 +1,124 @@
+"""Tests for the quality gate: replay buffer, surrogate evaluator, policy."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from src.continuous.candidates import Candidate
+from src.continuous.gate import (
+    GateTask,
+    SurrogateEvaluator,
+    build_replay_buffer,
+    build_surrogate_query,
+    run_gate,
+)
+
+from .conftest import make_episode
+
+
+def _candidate(episode_ids=("e1", "e2")) -> Candidate:
+    return Candidate(
+        candidate_id="cand-1",
+        skill_name="preserve-units",
+        skill_markdown="---\nname: preserve-units\ndescription: keep units\n---\nAlways include units.",
+        episode_ids=list(episode_ids),
+        cluster_size=len(episode_ids),
+        target_pattern="units",
+    )
+
+
+class _FakeVerifier:
+    def __init__(self, *, score=0.9, verdict=True, raise_exc=False, no_output=False):
+        self.score = score
+        self.verdict = verdict
+        self.raise_exc = raise_exc
+        self.no_output = no_output
+        self.last_query = None
+
+    async def run(self, query):
+        self.last_query = query
+        if self.raise_exc:
+            raise RuntimeError("verifier down")
+        if self.no_output:
+            return SimpleNamespace(output=None, model="m")
+        return SimpleNamespace(
+            output=SimpleNamespace(score=self.score, verdict=self.verdict,
+                                   assertions=["generalizes"], reasoning="ok"),
+            model="m",
+        )
+
+
+class TestReplayBuffer:
+    def test_excludes_candidate_episodes(self):
+        eps = [make_episode(f"e{i}", f"t{i}") for i in range(5)]
+        buf = build_replay_buffer(eps, _candidate(("e1", "e2")), size=10)
+        assert [e.episode_id for e in buf] == ["e0", "e3", "e4"]
+
+    def test_size_cap(self):
+        eps = [make_episode(f"x{i}", f"t{i}") for i in range(20)]
+        buf = build_replay_buffer(eps, _candidate(()), size=5)
+        assert len(buf) == 5
+
+    def test_empty_when_all_excluded(self):
+        eps = [make_episode("e1", "t"), make_episode("e2", "t")]
+        assert build_replay_buffer(eps, _candidate(("e1", "e2")), size=10) == []
+
+
+class TestSurrogateQuery:
+    def test_includes_skill_and_tasks_without_answers(self):
+        q = build_surrogate_query(_candidate(), [GateTask("held out task", "x")])
+        assert "preserve-units" in q
+        assert "held out task" in q
+
+    def test_no_tasks_handled(self):
+        q = build_surrogate_query(_candidate(), [])
+        assert "judge the skill on its own merits" in q
+
+    def test_caps_and_truncates(self):
+        tasks = [GateTask("t" * 1000, str(i)) for i in range(20)]
+        q = build_surrogate_query(_candidate(), tasks, max_tasks=3, task_chars=50)
+        assert "more not shown" in q
+        assert "…" in q
+
+
+class TestSurrogateEvaluator:
+    def test_pass(self):
+        ev = SurrogateEvaluator(_FakeVerifier(score=0.9, verdict=True))
+        out = asyncio.run(ev.evaluate(_candidate(), [GateTask("t")]))
+        assert out.verdict is True
+        assert out.score == 0.9
+        assert out.assertions == ["generalizes"]
+
+    def test_score_clamped(self):
+        out = asyncio.run(SurrogateEvaluator(_FakeVerifier(score=5.0)).evaluate(_candidate(), []))
+        assert out.score == 1.0
+
+    def test_no_output_is_fail(self):
+        out = asyncio.run(SurrogateEvaluator(_FakeVerifier(no_output=True)).evaluate(_candidate(), []))
+        assert out.verdict is False
+        assert out.score == 0.0
+
+    def test_verifier_exception_is_fail(self):
+        out = asyncio.run(SurrogateEvaluator(_FakeVerifier(raise_exc=True)).evaluate(_candidate(), []))
+        assert out.verdict is False
+        assert "verifier error" in out.detail
+
+
+class TestRunGate:
+    def test_pass_requires_verdict_and_threshold(self):
+        ev = SurrogateEvaluator(_FakeVerifier(score=0.9, verdict=True))
+        v = asyncio.run(run_gate(_candidate(), [make_episode("e", "t")], ev, threshold=0.6))
+        assert v.passed is True
+        assert v.method == "surrogate"
+        assert v.n_tasks == 1
+
+    def test_low_score_fails(self):
+        ev = SurrogateEvaluator(_FakeVerifier(score=0.4, verdict=True))
+        v = asyncio.run(run_gate(_candidate(), [], ev, threshold=0.6))
+        assert v.passed is False
+
+    def test_verdict_false_fails_even_high_score(self):
+        ev = SurrogateEvaluator(_FakeVerifier(score=0.99, verdict=False))
+        v = asyncio.run(run_gate(_candidate(), [], ev, threshold=0.6))
+        assert v.passed is False

--- a/tests/continuous/test_graduation.py
+++ b/tests/continuous/test_graduation.py
@@ -1,0 +1,133 @@
+"""Tests for graduation: skill install, branch versioning, merge archival."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from src.continuous.candidates import Candidate, CandidateStore
+from src.continuous.graduation import graduate, install_skill
+
+
+def _candidate(**kw) -> Candidate:
+    base = dict(
+        candidate_id="units-abc",
+        skill_name="preserve-units",
+        skill_markdown="---\nname: preserve-units\ndescription: keep units\n---\nAlways include units.",
+        episode_ids=["e1", "e2"],
+        cluster_size=2,
+    )
+    base.update(kw)
+    return Candidate(**base)
+
+
+class _FakeManager:
+    """Records create_program calls; returns a branch name."""
+
+    def __init__(self):
+        self.created = []
+
+    def get_current(self):
+        from src.registry.models import ProgramConfig
+        return ProgramConfig(name="base", system_prompt={"type": "preset", "preset": "claude_code"})
+
+    def create_program(self, name, config, parent=None):
+        self.created.append((name, parent, config.metadata))
+        return f"program/{name}"
+
+
+class TestInstallSkill:
+    def test_writes_skill_md(self, tmp_path):
+        path = install_skill(tmp_path / "skills", "my-skill", "---\nname: my-skill\n---\nbody")
+        assert (path / "SKILL.md").read_text().startswith("---")
+
+
+class TestGraduateNoManager:
+    def test_installs_and_marks(self, tmp_path):
+        skills = tmp_path / ".claude" / "skills"
+        store = CandidateStore(tmp_path / "cands")
+        store.save(_candidate())
+        result = graduate(_candidate(), skills_dir=skills, store=store, manager=None, gate_score=0.9)
+        assert (skills / "preserve-units" / "SKILL.md").is_file()
+        assert result.branch is None
+        assert store.get("units-abc").status == "graduated"
+
+
+class TestGraduateWithManager:
+    def test_creates_branch_with_metadata(self, tmp_path):
+        skills = tmp_path / ".claude" / "skills"
+        store = CandidateStore(tmp_path / "cands")
+        store.save(_candidate())
+        mgr = _FakeManager()
+        result = graduate(_candidate(), skills_dir=skills, store=store, manager=mgr, gate_score=0.85)
+        assert result.branch == "program/iter-skill-units-abc"
+        assert len(mgr.created) == 1
+        name, parent, metadata = mgr.created[0]
+        assert name == "iter-skill-units-abc"
+        assert parent is None  # branches from current HEAD
+        assert metadata["gate_score"] == 0.85
+        assert metadata["continuous"] is True
+
+
+class TestMergeArchival:
+    def test_merge_archives_originals(self, tmp_path):
+        skills = tmp_path / ".claude" / "skills"
+        # two originals exist in the live library
+        for name in ("preserve-units", "keep-units"):
+            (skills / name).mkdir(parents=True)
+            (skills / name / "SKILL.md").write_text(f"---\nname: {name}\n---\nx")
+        archive = tmp_path / "deprecated"
+        store = CandidateStore(tmp_path / "cands")
+        merged = _candidate(
+            candidate_id="merged-x", skill_name="units-merged",
+            source="merge", extra={"merged_from": ["preserve-units", "keep-units"]},
+        )
+        store.save(merged)
+        result = graduate(merged, skills_dir=skills, store=store, manager=None, archive_dir=archive)
+        assert (skills / "units-merged" / "SKILL.md").is_file()       # merged installed
+        assert set(result.archived_originals) == {"preserve-units", "keep-units"}
+        assert (archive / "preserve-units").is_dir()                  # originals archived
+        assert not (skills / "preserve-units").exists()
+
+
+class TestGraduateRealGit:
+    """Integration: graduation against a real git repo produces a program/* branch."""
+
+    def _git(self, *args, cwd):
+        subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+    def test_branch_created_and_skill_committed(self, tmp_path):
+        self._git("init", "-q", cwd=tmp_path)
+        self._git("config", "user.email", "t@t.co", cwd=tmp_path)
+        self._git("config", "user.name", "t", cwd=tmp_path)
+        (tmp_path / "README.md").write_text("x")
+        self._git("add", "-A", cwd=tmp_path)
+        self._git("commit", "-q", "-m", "init", cwd=tmp_path)
+
+        from src.registry import ProgramManager
+        from src.registry.models import ProgramConfig
+
+        mgr = ProgramManager(cwd=tmp_path)
+        mgr.create_program(
+            "base",
+            ProgramConfig(name="base", system_prompt={"type": "preset", "preset": "claude_code"},
+                          allowed_tools=["Read"]),
+        )
+        store = CandidateStore(tmp_path / ".evoskill" / "continuous" / "candidates")
+        store.save(_candidate())
+
+        result = graduate(
+            _candidate(), skills_dir=tmp_path / ".claude" / "skills",
+            store=store, manager=mgr,
+            archive_dir=tmp_path / ".evoskill" / "continuous" / "deprecated", gate_score=0.9,
+        )
+        assert result.branch == "program/iter-skill-units-abc"
+
+        branches = subprocess.run(["git", "branch", "--list"], cwd=tmp_path,
+                                   capture_output=True, text=True).stdout
+        assert "program/iter-skill-units-abc" in branches
+
+        tracked = subprocess.run(["git", "ls-files", ".claude/skills"], cwd=tmp_path,
+                                 capture_output=True, text=True).stdout
+        assert "preserve-units/SKILL.md" in tracked

--- a/tests/continuous/test_harvest.py
+++ b/tests/continuous/test_harvest.py
@@ -1,0 +1,193 @@
+"""Tests for the harvest pipeline and its CLI."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from src.continuous.candidates import CandidateStore
+from src.continuous.cluster import cluster_episodes
+from src.continuous.collector import (
+    GooseRawReader,
+    HarborTrajectoryReader,
+    JsonlReader,
+)
+from src.continuous.episode import Outcome
+from src.continuous.harvest import (
+    build_distiller_query,
+    build_readers,
+    harvest,
+    slugify_skill_name,
+)
+
+from .conftest import make_episode
+
+
+class FakeDistiller:
+    """Stand-in for src.harness.Agent: returns a canned distiller response."""
+
+    def __init__(self, *, name="distilled", skill="---\nname: s\ndescription: d\n---\nbody",
+                 raise_on=None, empty=False):
+        self.name = name
+        self.skill = skill
+        self.raise_on = raise_on
+        self.empty = empty
+        self.calls = 0
+
+    async def run(self, query):
+        self.calls += 1
+        if self.raise_on and self.raise_on in query:
+            raise RuntimeError("boom")
+        if self.empty:
+            return SimpleNamespace(output=SimpleNamespace(candidate_skill="", skill_name=""), model="m")
+        out = SimpleNamespace(
+            skill_name=self.name, candidate_skill=self.skill,
+            target_pattern="pat", reasoning="why",
+        )
+        return SimpleNamespace(output=out, model="fake-model")
+
+
+def _failures(prefix, text, n):
+    return [make_episode(f"{prefix}-{i}", text) for i in range(n)]
+
+
+# ── pure helpers ───────────────────────────────────────────────────────────────
+
+
+class TestSlugify:
+    def test_basic(self):
+        assert slugify_skill_name("My Skill!!") == "my-skill"
+
+    def test_empty_falls_back(self):
+        assert slugify_skill_name("   ") == "distilled-skill"
+
+    def test_collapses_separators(self):
+        assert slugify_skill_name("a__b  c") == "a-b-c"
+
+
+class TestBuildReaders:
+    def test_harbor_and_goose_and_jsonl(self, tmp_path):
+        readers = build_readers(
+            ["harbor", "goose", "jsonl"],
+            traces_root=str(tmp_path), jsonl_path=str(tmp_path / "t.jsonl"),
+        )
+        kinds = [type(r) for r in readers]
+        assert kinds == [HarborTrajectoryReader, GooseRawReader, JsonlReader]
+
+    def test_skips_sources_without_path(self):
+        assert build_readers(["harbor", "jsonl"], traces_root=None, jsonl_path=None) == []
+
+    def test_skips_unknown_source(self, tmp_path):
+        assert build_readers(["mystery"], traces_root=str(tmp_path)) == []
+
+
+class TestBuildDistillerQuery:
+    def test_includes_size_focus_terms_and_examples(self):
+        eps = _failures("d", "compute the federal deficit fiscal quarter", 4)
+        cluster = cluster_episodes(eps, min_cluster_size=3)[0]
+        q = build_distiller_query(cluster)
+        assert "4 episodes" in q
+        assert "failure" in q
+        assert "Example episodes" in q
+        assert "deficit" in q
+
+    def test_truncates_and_caps_examples(self):
+        eps = _failures("d", "x " * 1000 + "deficit", 10)
+        cluster = cluster_episodes(eps, min_cluster_size=3)[0]
+        q = build_distiller_query(cluster, max_examples=2)
+        assert "more similar episodes not shown" in q
+
+
+# ── harvest() ────────────────────────────────────────────────────────────────
+
+
+class TestHarvest:
+    def test_writes_candidates(self, tmp_path):
+        store = CandidateStore(tmp_path / "c")
+        reader = _StaticReader(_failures("d", "compute the federal deficit fiscal quarter", 5))
+        distiller = FakeDistiller()
+        result = asyncio.run(harvest(
+            readers=[reader], distiller=distiller, store=store,
+            min_cluster_size=3, focus=Outcome.FAILURE,
+        ))
+        assert result.episodes_collected == 5
+        assert result.num_candidates == 1
+        assert result.failed_distillations == 0
+        assert len(store.list()) == 1
+        assert distiller.calls == 1
+
+    def test_no_clusters_no_candidates(self, tmp_path):
+        store = CandidateStore(tmp_path / "c")
+        reader = _StaticReader(_failures("d", "unique solo task", 1))
+        result = asyncio.run(harvest(
+            readers=[reader], distiller=FakeDistiller(), store=store, min_cluster_size=3,
+        ))
+        assert result.num_candidates == 0
+        assert result.clusters == []
+
+    def test_distiller_exception_counts_as_failed(self, tmp_path):
+        store = CandidateStore(tmp_path / "c")
+        reader = _StaticReader(_failures("d", "compute the federal deficit fiscal quarter", 4))
+        result = asyncio.run(harvest(
+            readers=[reader], distiller=FakeDistiller(raise_on="episodes"),
+            store=store, min_cluster_size=3,
+        ))
+        assert result.num_candidates == 0
+        assert result.failed_distillations == 1
+
+    def test_empty_skill_counts_as_failed(self, tmp_path):
+        store = CandidateStore(tmp_path / "c")
+        reader = _StaticReader(_failures("d", "compute the federal deficit fiscal quarter", 4))
+        result = asyncio.run(harvest(
+            readers=[reader], distiller=FakeDistiller(empty=True), store=store, min_cluster_size=3,
+        ))
+        assert result.num_candidates == 0
+        assert result.failed_distillations == 1
+
+    def test_max_candidates_caps_distillations(self, tmp_path):
+        store = CandidateStore(tmp_path / "c")
+        eps = (_failures("a", "federal deficit budget fiscal quarter", 4)
+               + _failures("b", "customs duty receipts revenue bulletin", 4)
+               + _failures("c", "treasury bond maturity schedule listing", 4))
+        distiller = FakeDistiller()
+        result = asyncio.run(harvest(
+            readers=[_StaticReader(eps)], distiller=distiller, store=store,
+            min_cluster_size=3, max_candidates=2,
+        ))
+        assert len(result.clusters) == 2
+        assert distiller.calls == 2
+
+    def test_focus_success(self, tmp_path):
+        store = CandidateStore(tmp_path / "c")
+        eps = [make_episode(f"s-{i}", "reusable winning workflow steps", outcome=Outcome.SUCCESS)
+               for i in range(3)]
+        result = asyncio.run(harvest(
+            readers=[_StaticReader(eps)], distiller=FakeDistiller(), store=store,
+            min_cluster_size=3, focus=Outcome.SUCCESS,
+        ))
+        assert result.num_candidates == 1
+        assert store.list()[0].outcome_focus == "success"
+
+    def test_candidate_carries_provenance(self, tmp_path):
+        store = CandidateStore(tmp_path / "c")
+        reader = _StaticReader(_failures("d", "compute the federal deficit fiscal quarter", 4))
+        asyncio.run(harvest(readers=[reader], distiller=FakeDistiller(name="My Skill"),
+                            store=store, min_cluster_size=3))
+        c = store.list()[0]
+        assert c.skill_name == "my-skill"          # slugified
+        assert c.cluster_size == 4
+        assert len(c.episode_ids) == 4
+        assert c.model_name == "fake-model"
+        assert c.source == "harvest"
+
+
+class _StaticReader:
+    """A TraceReader that yields a fixed list of episodes."""
+
+    source = "static"
+
+    def __init__(self, episodes):
+        self._episodes = episodes
+
+    def read_all(self):
+        return iter(self._episodes)

--- a/tests/continuous/test_library.py
+++ b/tests/continuous/test_library.py
@@ -1,0 +1,72 @@
+"""Tests for the skill library reader."""
+
+from __future__ import annotations
+
+from src.continuous.library import SkillLibrary, parse_skill_file
+
+
+def _write_skill(skills_dir, name, *, frontmatter=True, description="does a thing", body="The rule."):
+    d = skills_dir / name
+    d.mkdir(parents=True)
+    if frontmatter:
+        text = f"---\nname: {name}\ndescription: {description}\n---\n\n{body}"
+    else:
+        text = body
+    (d / "SKILL.md").write_text(text)
+    return d / "SKILL.md"
+
+
+class TestParseSkillFile:
+    def test_parses_frontmatter(self, tmp_path):
+        p = _write_skill(tmp_path, "my-skill", description="preserve units")
+        skill = parse_skill_file(p)
+        assert skill.name == "my-skill"
+        assert skill.description == "preserve units"
+        assert skill.body == "The rule."
+        assert "my-skill: preserve units" == skill.text
+
+    def test_no_frontmatter_uses_dir_name(self, tmp_path):
+        p = _write_skill(tmp_path, "bare", frontmatter=False, body="just body text")
+        skill = parse_skill_file(p)
+        assert skill.name == "bare"
+        assert skill.description == ""
+        assert skill.body == "just body text"
+
+    def test_bad_yaml_tolerated(self, tmp_path):
+        d = tmp_path / "broken"
+        d.mkdir()
+        (d / "SKILL.md").write_text("---\nname: [unclosed\n---\nbody")
+        skill = parse_skill_file(d / "SKILL.md")
+        assert skill.name == "broken"  # falls back to dir name
+
+    def test_text_strips_trailing_colon_when_no_description(self, tmp_path):
+        p = _write_skill(tmp_path, "nodesc", description="")
+        skill = parse_skill_file(p)
+        assert skill.text == "nodesc"
+
+
+class TestSkillLibrary:
+    def test_list_and_names(self, tmp_path):
+        sd = tmp_path / "skills"
+        _write_skill(sd, "alpha")
+        _write_skill(sd, "beta")
+        lib = SkillLibrary(sd)
+        assert lib.names() == ["alpha", "beta"]
+        assert len(lib.list()) == 2
+
+    def test_get_by_name_and_dir(self, tmp_path):
+        sd = tmp_path / "skills"
+        _write_skill(sd, "gamma")
+        lib = SkillLibrary(sd)
+        assert lib.get("gamma") is not None
+        assert lib.get("missing") is None
+
+    def test_ignores_dirs_without_skill_md(self, tmp_path):
+        sd = tmp_path / "skills"
+        _write_skill(sd, "real")
+        (sd / "empty").mkdir()
+        (sd / "loose.txt").write_text("x")
+        assert SkillLibrary(sd).names() == ["real"]
+
+    def test_missing_dir(self, tmp_path):
+        assert SkillLibrary(tmp_path / "nope").list() == []

--- a/tests/continuous/test_lifecycle.py
+++ b/tests/continuous/test_lifecycle.py
@@ -1,0 +1,203 @@
+"""Tests for skill-library lifecycle operations."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from src.continuous.candidates import CandidateStore
+from src.continuous.library import Skill
+from src.continuous.lifecycle import (
+    archive_skill,
+    build_merge_query,
+    evaluate_deprecation,
+    find_duplicates,
+    propose_merge,
+    restore_skill,
+    select_skills,
+)
+from src.continuous.similarity import SimilarityBackend
+from src.continuous.skill_stats import SkillStatsStore
+
+
+def _skill(name: str) -> Skill:
+    return Skill(name=name, description=f"desc {name}", body="body", path=Path(f"{name}/SKILL.md"))
+
+
+class MatrixBackend(SimilarityBackend):
+    """Similarity driven by an explicit matrix keyed on skill .text."""
+
+    name = "matrix"
+
+    def __init__(self, texts: list[str], matrix: list[list[float]]):
+        self.idx = {t: i for i, t in enumerate(texts)}
+        self.m = matrix
+
+    def pairwise(self, texts):
+        return [[self.m[self.idx[a]][self.idx[b]] for b in texts] for a in texts]
+
+    def rank(self, query, candidates):
+        scored = [(i, self.m[self.idx[query]][self.idx[c]]) for i, c in enumerate(candidates)]
+        scored.sort(key=lambda kv: kv[1], reverse=True)
+        return scored
+
+
+class TestFindDuplicates:
+    def test_groups_above_threshold(self):
+        skills = [_skill("a"), _skill("b"), _skill("c")]
+        texts = [s.text for s in skills]
+        # a~b high, c separate
+        m = [[1.0, 0.95, 0.1], [0.95, 1.0, 0.1], [0.1, 0.1, 1.0]]
+        groups = find_duplicates(skills, MatrixBackend(texts, m), threshold=0.88)
+        assert len(groups) == 1
+        assert set(groups[0].names) == {"a", "b"}
+        assert groups[0].max_similarity == 0.95
+
+    def test_union_find_transitivity(self):
+        skills = [_skill("a"), _skill("b"), _skill("c")]
+        texts = [s.text for s in skills]
+        # a~b and b~c high, a~c low → all three transitively grouped
+        m = [[1.0, 0.9, 0.4], [0.9, 1.0, 0.9], [0.4, 0.9, 1.0]]
+        groups = find_duplicates(skills, MatrixBackend(texts, m), threshold=0.85)
+        assert len(groups) == 1
+        assert set(groups[0].names) == {"a", "b", "c"}
+
+    def test_no_duplicates(self):
+        skills = [_skill("a"), _skill("b")]
+        texts = [s.text for s in skills]
+        m = [[1.0, 0.2], [0.2, 1.0]]
+        assert find_duplicates(skills, MatrixBackend(texts, m), threshold=0.88) == []
+
+    def test_fewer_than_two_skills(self):
+        assert find_duplicates([_skill("a")], MatrixBackend(["x"], [[1.0]]), threshold=0.5) == []
+
+
+class TestSelectSkills:
+    def test_top_k_ordering(self):
+        skills = [_skill("a"), _skill("b"), _skill("c")]
+        texts = ["q", *[s.text for s in skills]]
+        # q closest to b, then a, then c
+        m = [
+            [1.0, 0.5, 0.9, 0.2],
+            [0.5, 1.0, 0.0, 0.0],
+            [0.9, 0.0, 1.0, 0.0],
+            [0.2, 0.0, 0.0, 1.0],
+        ]
+        matches = select_skills(skills, "q", MatrixBackend(texts, m), k=2)
+        assert [m.skill.name for m in matches] == ["b", "a"]
+
+    def test_min_score_filters(self):
+        skills = [_skill("a"), _skill("b")]
+        texts = ["q", _skill("a").text, _skill("b").text]
+        m = [[1.0, 0.9, 0.1], [0.9, 1.0, 0.0], [0.1, 0.0, 1.0]]
+        matches = select_skills(skills, "q", MatrixBackend(texts, m), k=5, min_score=0.5)
+        assert [x.skill.name for x in matches] == ["a"]
+
+    def test_empty_library(self):
+        assert select_skills([], "q", MatrixBackend(["q"], [[1.0]])) == []
+
+
+class TestEvaluateDeprecation:
+    def test_strikes_accrue_to_candidate(self, tmp_path):
+        store = SkillStatsStore(tmp_path / "s.json")
+        s = store.get("dead")
+        s.episodes_active = 5  # active but zero contribution
+        store.upsert(s)
+        rep = None
+        for _ in range(3):
+            rep = evaluate_deprecation(store, ["dead"], baseline=0.0, strikes_limit=3)
+        assert rep.candidates == ["dead"]
+        assert store.get("dead").deprecation_strikes == 3
+
+    def test_recovery_resets_strikes(self, tmp_path):
+        store = SkillStatsStore(tmp_path / "s.json")
+        s = store.get("x")
+        s.episodes_active = 2
+        s.deprecation_strikes = 2
+        store.upsert(s)
+        # now it has contribution > baseline
+        s2 = store.get("x")
+        s2.contribution = 1.0
+        store.upsert(s2)
+        rep = evaluate_deprecation(store, ["x"], baseline=0.0, strikes_limit=3)
+        assert "x" in rep.recovered
+        assert store.get("x").deprecation_strikes == 0
+
+    def test_unused_skill_not_struck(self, tmp_path):
+        store = SkillStatsStore(tmp_path / "s.json")
+        rep = evaluate_deprecation(store, ["never"], baseline=0.0, strikes_limit=3)
+        assert rep.unused == ["never"]
+        assert rep.struck == []
+        assert rep.candidates == []
+
+
+class TestArchive:
+    def _make_skill_dir(self, root, name):
+        d = root / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("x")
+        return d
+
+    def test_archive_and_restore(self, tmp_path):
+        sd = tmp_path / "skills"
+        self._make_skill_dir(sd, "foo")
+        arch = tmp_path / "deprecated"
+        archive_skill(sd, "foo", arch)
+        assert (arch / "foo" / "SKILL.md").is_file()
+        assert not (sd / "foo").exists()
+        restore_skill(arch, "foo", sd)
+        assert (sd / "foo" / "SKILL.md").is_file()
+        assert not (arch / "foo").exists()
+
+    def test_archive_missing_raises(self, tmp_path):
+        import pytest
+        with pytest.raises(FileNotFoundError):
+            archive_skill(tmp_path / "skills", "nope", tmp_path / "arch")
+
+    def test_archive_overwrites_existing(self, tmp_path):
+        sd = tmp_path / "skills"
+        arch = tmp_path / "deprecated"
+        self._make_skill_dir(sd, "foo")
+        self._make_skill_dir(arch, "foo")  # stale archive copy
+        archive_skill(sd, "foo", arch)  # should overwrite, not error
+        assert (arch / "foo" / "SKILL.md").is_file()
+
+
+class _FakeMerger:
+    def __init__(self, *, empty=False):
+        self.empty = empty
+
+    async def run(self, query):
+        skill = "" if self.empty else "---\nname: merged\ndescription: m\n---\nrule"
+        return SimpleNamespace(
+            output=SimpleNamespace(skill_name="Merged Skill", candidate_skill=skill,
+                                   target_pattern="", reasoning="r"),
+            model="fake",
+        )
+
+
+class TestMerge:
+    def test_build_merge_query_lists_skills(self):
+        q = build_merge_query([_skill("a"), _skill("b")])
+        assert "Merge the following 2" in q
+        assert "Skill 1: a" in q and "Skill 2: b" in q
+
+    def test_propose_merge_writes_candidate(self, tmp_path):
+        store = CandidateStore(tmp_path / "c")
+        cand = asyncio.run(propose_merge([_skill("a"), _skill("b")], _FakeMerger(), store))
+        assert cand is not None
+        assert cand.skill_name == "merged-skill"
+        assert cand.source == "merge"
+        assert cand.extra["merged_from"] == ["a", "b"]
+        assert len(store.list()) == 1
+
+    def test_propose_merge_needs_two(self, tmp_path):
+        store = CandidateStore(tmp_path / "c")
+        assert asyncio.run(propose_merge([_skill("a")], _FakeMerger(), store)) is None
+
+    def test_propose_merge_empty_output(self, tmp_path):
+        store = CandidateStore(tmp_path / "c")
+        cand = asyncio.run(propose_merge([_skill("a"), _skill("b")], _FakeMerger(empty=True), store))
+        assert cand is None
+        assert store.list() == []

--- a/tests/continuous/test_loop.py
+++ b/tests/continuous/test_loop.py
@@ -1,0 +1,294 @@
+"""Tests for the continuous tick and the watch loop."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from src.continuous.candidates import CandidateStore
+from src.continuous.collector import TraceCursor
+from src.continuous.episode import Outcome
+from src.continuous.loop import (
+    CostMeter,
+    MeteredAgent,
+    TickConfig,
+    run_tick,
+    run_watch_loop,
+)
+from src.continuous.skill_stats import SkillStatsStore
+
+from .conftest import make_episode
+
+
+class _StaticReader:
+    source = "static"
+
+    def __init__(self, episodes):
+        self._episodes = episodes
+
+    def read_all(self):
+        return iter(self._episodes)
+
+
+def _similar_failures(n, text="compute the federal deficit fiscal quarter", prefix="d"):
+    return [make_episode(f"{prefix}-{i}", text) for i in range(n)]
+
+
+class _FakeDistiller:
+    def __init__(self, *, cost=0.01):
+        self.cost = cost
+        self.calls = 0
+
+    async def run(self, query):
+        self.calls += 1
+        return SimpleNamespace(
+            output=SimpleNamespace(
+                skill_name=f"skill-{self.calls}",
+                candidate_skill=f"---\nname: skill-{self.calls}\ndescription: d\n---\nrule",
+                target_pattern="deficit", reasoning="r"),
+            model="m", total_cost_usd=self.cost,
+        )
+
+
+class _FakeVerifier:
+    def __init__(self, *, passing=True, cost=0.0):
+        self.passing = passing
+        self.cost = cost
+
+    async def run(self, query):
+        return SimpleNamespace(
+            output=SimpleNamespace(score=0.9 if self.passing else 0.3, verdict=self.passing,
+                                   assertions=["a"], reasoning="ok"),
+            model="m", total_cost_usd=self.cost,
+        )
+
+
+def _tick(tmp_path, **kw):
+    """Helper: run a tick with sensible temp stores."""
+    store = CandidateStore(tmp_path / "cands")
+    cursor = kw.pop("cursor", None) or TraceCursor(tmp_path / "cursor.json")
+    return asyncio.run(run_tick(store=store, cursor=cursor, **kw)), store, cursor
+
+
+# ── CostMeter / MeteredAgent ──────────────────────────────────────────────────
+
+
+class TestCostMeter:
+    def test_accumulates_and_threshold(self):
+        m = CostMeter()
+        m.add(0.03)
+        m.add(0.04)
+        assert abs(m.spent - 0.07) < 1e-9
+        assert m.exceeded(0.05) is True
+        assert m.exceeded(0.10) is False
+        assert m.exceeded(None) is False
+        assert m.exceeded(0.0) is False  # 0 = unlimited
+
+    def test_metered_agent_records_cost(self):
+        meter = CostMeter()
+
+        class A:
+            async def run(self, q):
+                return SimpleNamespace(output="x", total_cost_usd=0.05)
+
+        trace = asyncio.run(MeteredAgent(A(), meter).run("q"))
+        assert trace.output == "x"
+        assert meter.spent == 0.05
+
+
+# ── review mode ──────────────────────────────────────────────────────────────
+
+
+class TestReviewMode:
+    def test_discovers_without_graduating(self, tmp_path):
+        cfg = TickConfig(mode="review", min_cluster_size=3, max_candidates=2)
+        d = _FakeDistiller()
+        report, store, _ = _tick(
+            tmp_path, readers=[_StaticReader(_similar_failures(5))], distiller=d,
+            skills_dir=tmp_path / "skills", config=cfg,
+        )
+        assert report.episodes_collected == 5
+        assert report.num_candidates == 1
+        assert report.num_graduated == 0
+        assert report.cost_usd == 0.01  # one distill call
+        assert len(store.list()) == 1
+
+    def test_watermark_advances(self, tmp_path):
+        cfg = TickConfig(mode="review", min_cluster_size=3)
+        cursor = TraceCursor(tmp_path / "cursor.json")
+        eps = _similar_failures(4)
+        _tick(tmp_path, readers=[_StaticReader(eps)], distiller=_FakeDistiller(),
+              cursor=cursor, config=cfg)
+        report2, _, _ = _tick(tmp_path, readers=[_StaticReader(eps)], distiller=_FakeDistiller(),
+                              cursor=cursor, config=cfg)
+        assert report2.episodes_collected == 0  # all watermarked
+
+
+# ── auto mode ────────────────────────────────────────────────────────────────
+
+
+class TestAutoMode:
+    def test_gates_and_graduates(self, tmp_path):
+        cfg = TickConfig(mode="auto", min_cluster_size=3, graduation_threshold=0.6, max_graduations=5)
+        report, store, _ = _tick(
+            tmp_path, readers=[_StaticReader(_similar_failures(5))], distiller=_FakeDistiller(),
+            verifier=_FakeVerifier(passing=True), skills_dir=tmp_path / "skills",
+            manager=None, config=cfg,
+        )
+        assert report.num_candidates == 1
+        assert report.num_graduated == 1
+        assert (tmp_path / "skills" / "skill-1" / "SKILL.md").is_file()
+        cand_id = report.candidates[0].candidate_id
+        assert store.get(cand_id).status == "graduated"
+        assert report.gated[cand_id].passed is True
+
+    def test_gate_failure_blocks_graduation(self, tmp_path):
+        cfg = TickConfig(mode="auto", min_cluster_size=3)
+        report, store, _ = _tick(
+            tmp_path, readers=[_StaticReader(_similar_failures(5))], distiller=_FakeDistiller(),
+            verifier=_FakeVerifier(passing=False), skills_dir=tmp_path / "skills", config=cfg,
+        )
+        assert report.num_graduated == 0
+        cand_id = report.candidates[0].candidate_id
+        assert store.get(cand_id).status == "pending"
+        assert store.get(cand_id).extra["gate_passed"] is False  # verdict recorded
+
+    def test_rate_limit(self, tmp_path):
+        # 3 distinct clusters → 3 candidates, but max_graduations=2
+        eps = (_similar_failures(4, "deficit budget fiscal quarter total", "a")
+               + _similar_failures(4, "customs duty receipts revenue bulletin", "b")
+               + _similar_failures(4, "treasury bond maturity schedule listing", "c"))
+        cfg = TickConfig(mode="auto", min_cluster_size=3, max_graduations=2)
+        report, _, _ = _tick(
+            tmp_path, readers=[_StaticReader(eps)], distiller=_FakeDistiller(),
+            verifier=_FakeVerifier(passing=True), skills_dir=tmp_path / "skills", config=cfg,
+        )
+        assert report.num_graduated == 2
+        assert report.stopped_reason == "max_graduations"
+
+    def test_cost_ceiling_stops(self, tmp_path):
+        eps = (_similar_failures(4, "deficit budget fiscal quarter", "a")
+               + _similar_failures(4, "customs duty receipts revenue", "b"))
+        # distill 2 × 0.01 = 0.02; gate 0.10 each → ceiling 0.05 trips after first graduation
+        cfg = TickConfig(mode="auto", min_cluster_size=3, max_graduations=99, cost_ceiling=0.05)
+        report, _, _ = _tick(
+            tmp_path, readers=[_StaticReader(eps)], distiller=_FakeDistiller(cost=0.01),
+            verifier=_FakeVerifier(passing=True, cost=0.10), skills_dir=tmp_path / "skills", config=cfg,
+        )
+        assert report.stopped_reason == "cost_ceiling"
+        assert report.num_graduated < 2
+
+    def test_no_verifier_stops(self, tmp_path):
+        cfg = TickConfig(mode="auto", min_cluster_size=3)
+        report, _, _ = _tick(
+            tmp_path, readers=[_StaticReader(_similar_failures(4))], distiller=_FakeDistiller(),
+            verifier=None, skills_dir=tmp_path / "skills", config=cfg,
+        )
+        assert report.stopped_reason == "no verifier for auto mode"
+        assert report.num_graduated == 0
+
+    def test_dedup_guard_skips_existing(self, tmp_path):
+        # An existing live skill the candidate duplicates.
+        sd = tmp_path / "skills"
+        (sd / "skill-1").mkdir(parents=True)
+        (sd / "skill-1" / "SKILL.md").write_text("---\nname: skill-1\ndescription: deficit\n---\nx")
+
+        class DupBackend:
+            name = "dup"
+            def rank(self, query, candidates):
+                return [(0, 0.99)]  # always "duplicate"
+            def pairwise(self, texts):
+                return [[1.0]]
+
+        cfg = TickConfig(mode="auto", min_cluster_size=3, dedupe_similarity=0.88)
+        report, _, _ = _tick(
+            tmp_path, readers=[_StaticReader(_similar_failures(4))], distiller=_FakeDistiller(),
+            verifier=_FakeVerifier(passing=True), skills_dir=sd,
+            similarity_backend=DupBackend(), config=cfg,
+        )
+        assert len(report.skipped_duplicates) == 1
+        assert report.num_graduated == 0
+
+
+# ── credit + deprecation ─────────────────────────────────────────────────────
+
+
+class TestCreditAndDeprecation:
+    def test_credit_assigned(self, tmp_path):
+        eps = _similar_failures(3)
+        for e in eps:
+            e.skills_active = ["some-skill"]
+            e.outcome = Outcome.SUCCESS  # success so credit accrues
+        stats = SkillStatsStore(tmp_path / "stats.json")
+        cfg = TickConfig(mode="review", min_cluster_size=99)  # no clustering needed
+        _tick(tmp_path, readers=[_StaticReader(eps)], distiller=_FakeDistiller(),
+              stats_store=stats, skills_dir=tmp_path / "skills", config=cfg)
+        assert stats.get("some-skill").episodes_active == 3
+
+    def test_deprecation_reported(self, tmp_path):
+        sd = tmp_path / "skills"
+        (sd / "dead").mkdir(parents=True)
+        (sd / "dead" / "SKILL.md").write_text("---\nname: dead\ndescription: d\n---\nx")
+        stats = SkillStatsStore(tmp_path / "stats.json")
+        s = stats.get("dead")
+        s.episodes_active = 5  # active, zero contribution
+        s.deprecation_strikes = 2
+        stats.upsert(s)
+        cfg = TickConfig(mode="review", min_cluster_size=99,
+                         deprecation_baseline=0.0, deprecation_strikes=3)
+        report, _, _ = _tick(tmp_path, readers=[_StaticReader([])], distiller=_FakeDistiller(),
+                             stats_store=stats, skills_dir=sd, config=cfg)
+        assert report.deprecation is not None
+        assert "dead" in report.deprecation.candidates  # crossed the strike limit
+
+    def test_auto_deprecate_archives(self, tmp_path):
+        sd = tmp_path / "skills"
+        (sd / "dead").mkdir(parents=True)
+        (sd / "dead" / "SKILL.md").write_text("---\nname: dead\ndescription: d\n---\nx")
+        stats = SkillStatsStore(tmp_path / "stats.json")
+        s = stats.get("dead")
+        s.episodes_active = 5
+        s.deprecation_strikes = 2  # one more strike crosses the limit
+        stats.upsert(s)
+        archive = tmp_path / "deprecated"
+        # auto mode + auto_deprecate + no episodes (so no candidates/gating needed)
+        cfg = TickConfig(mode="auto", min_cluster_size=99, deprecation_strikes=3,
+                         auto_deprecate=True)
+        report, _, _ = _tick(
+            tmp_path, readers=[_StaticReader([])], distiller=_FakeDistiller(),
+            verifier=_FakeVerifier(), stats_store=stats, skills_dir=sd,
+            archive_dir=archive, config=cfg,
+        )
+        assert "dead" in report.archived
+        assert (archive / "dead" / "SKILL.md").is_file()
+        assert not (sd / "dead").exists()
+
+
+# ── watch loop ───────────────────────────────────────────────────────────────
+
+
+class TestWatchLoop:
+    def test_max_ticks(self):
+        calls = {"n": 0}
+        sleeps = []
+
+        def tick():
+            calls["n"] += 1
+            return SimpleNamespace()
+
+        n = run_watch_loop(tick, max_ticks=3, interval_sec=5, sleep=sleeps.append)
+        assert n == 3
+        assert calls["n"] == 3
+        assert sleeps == [5, 5]  # slept between ticks, not after the last
+
+    def test_once(self):
+        calls = {"n": 0}
+        n = run_watch_loop(lambda: calls.__setitem__("n", calls["n"] + 1),
+                           once=True, sleep=lambda s: None)
+        assert n == 1
+
+    def test_keyboard_interrupt_stops_cleanly(self):
+        def tick():
+            raise KeyboardInterrupt
+        n = run_watch_loop(tick, max_ticks=5, sleep=lambda s: None)
+        assert n == 0

--- a/tests/continuous/test_signals.py
+++ b/tests/continuous/test_signals.py
@@ -1,0 +1,61 @@
+"""Tests for outcome-signal extraction."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.continuous.episode import Outcome, SignalKind
+from src.continuous.signals import clamp01, no_signal, signal_from_reward
+
+
+class TestClamp01:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [(-1.0, 0.0), (0.0, 0.0), (0.5, 0.5), (1.0, 1.0), (2.0, 1.0)],
+    )
+    def test_clamps(self, value, expected):
+        assert clamp01(value) == expected
+
+
+class TestSignalFromReward:
+    def test_full_reward_is_success(self):
+        sig = signal_from_reward(1.0)
+        assert sig.outcome is Outcome.SUCCESS
+        assert sig.value == 1.0
+        assert sig.confidence == 1.0
+        assert sig.kind is SignalKind.VERIFIER_REWARD
+
+    def test_zero_reward_is_failure(self):
+        sig = signal_from_reward(0.0)
+        assert sig.outcome is Outcome.FAILURE
+        assert sig.value == 0.0
+
+    def test_partial_reward_is_failure_by_default_but_value_preserved(self):
+        sig = signal_from_reward(0.5)
+        assert sig.outcome is Outcome.FAILURE
+        assert sig.value == 0.5
+
+    def test_partial_reward_passes_with_lower_threshold(self):
+        sig = signal_from_reward(0.5, success_threshold=0.5)
+        assert sig.outcome is Outcome.SUCCESS
+
+    def test_reward_above_one_clamps_value(self):
+        sig = signal_from_reward(3.0)
+        assert sig.value == 1.0
+        assert sig.outcome is Outcome.SUCCESS
+
+    def test_custom_evidence(self):
+        sig = signal_from_reward(1.0, evidence="custom")
+        assert sig.evidence == "custom"
+
+    def test_default_evidence_mentions_reward(self):
+        sig = signal_from_reward(0.0)
+        assert "reward" in sig.evidence
+
+
+class TestNoSignal:
+    def test_unknown_zero_confidence(self):
+        sig = no_signal()
+        assert sig.outcome is Outcome.UNKNOWN
+        assert sig.confidence == 0.0
+        assert sig.kind is SignalKind.NONE

--- a/tests/continuous/test_similarity.py
+++ b/tests/continuous/test_similarity.py
@@ -1,0 +1,124 @@
+"""Tests for similarity backends, embedding cache, and the factory."""
+
+from __future__ import annotations
+
+from src.continuous.similarity import (
+    EmbeddingCache,
+    EmbeddingSimilarity,
+    LexicalSimilarity,
+    make_openai_embedder,
+    make_similarity_backend,
+)
+
+
+class TestLexicalSimilarity:
+    def test_rank_orders_by_overlap(self):
+        b = LexicalSimilarity()
+        ranked = b.rank(
+            "measurement units for revenue",
+            ["always include measurement units", "unrelated cooking recipe steps"],
+        )
+        assert ranked[0][0] == 0  # the units candidate ranks first
+        assert ranked[0][1] >= ranked[1][1]
+
+    def test_pairwise_diagonal_and_symmetry(self):
+        b = LexicalSimilarity()
+        m = b.pairwise(["alpha beta gamma", "alpha beta gamma", "totally different words"])
+        assert m[0][0] == 1.0
+        assert m[0][1] == m[1][0]
+        assert m[0][1] > m[0][2]
+
+    def test_empty_text_has_zero_self_similarity(self):
+        b = LexicalSimilarity()
+        m = b.pairwise(["", "real words here"])
+        assert m[0][0] == 0.0  # empty doc → zero vector
+
+    def test_rank_empty_candidates(self):
+        assert LexicalSimilarity().rank("q", []) == []
+
+
+class TestEmbeddingCache:
+    def test_put_get_roundtrip(self, tmp_path):
+        c = EmbeddingCache(tmp_path / "e.json")
+        assert c.get("x") is None
+        c.put("x", [1.0, 2.0])
+        c.save()
+        reloaded = EmbeddingCache(tmp_path / "e.json")
+        assert reloaded.get("x") == [1.0, 2.0]
+
+    def test_corrupt_file_is_empty(self, tmp_path):
+        (tmp_path / "e.json").write_text("{bad")
+        assert EmbeddingCache(tmp_path / "e.json").get("x") is None
+
+    def test_none_path_is_noop(self):
+        c = EmbeddingCache(None)
+        c.put("x", [1.0])
+        c.save()  # must not raise
+        assert c.get("x") == [1.0]
+
+
+class _CountingEmbedder:
+    def __init__(self):
+        self.calls = 0
+        self.total_texts = 0
+
+    def __call__(self, texts):
+        self.calls += 1
+        self.total_texts += len(texts)
+        # deterministic vector by length + first ordinal
+        return [[float(len(t)), float(ord(t[0]) if t else 0)] for t in texts]
+
+
+class TestEmbeddingSimilarity:
+    def test_rank_uses_embeddings(self):
+        emb = EmbeddingSimilarity(_CountingEmbedder())
+        ranked = emb.rank("hello", ["hello", "x"])
+        assert ranked[0][0] == 0  # identical text most similar
+
+    def test_cache_avoids_reembedding(self, tmp_path):
+        embedder = _CountingEmbedder()
+        cache = EmbeddingCache(tmp_path / "e.json")
+        emb = EmbeddingSimilarity(embedder, cache)
+        emb.rank("a", ["bb", "ccc"])
+        first_calls = embedder.calls
+        emb.rank("a", ["bb", "ccc"])  # all cached now
+        assert embedder.calls == first_calls  # no new API call
+
+    def test_dedups_misses_before_calling(self, tmp_path):
+        embedder = _CountingEmbedder()
+        emb = EmbeddingSimilarity(embedder, EmbeddingCache(tmp_path / "e.json"))
+        emb.pairwise(["dup", "dup", "other"])
+        # only 2 unique texts embedded despite 3 inputs
+        assert embedder.total_texts == 2
+
+    def test_no_cache_path(self):
+        emb = EmbeddingSimilarity(_CountingEmbedder(), None)
+        assert emb.rank("q", ["q"])[0][1] > 0.9
+
+
+class TestFactory:
+    def test_lexical_backend_requested(self):
+        b = make_similarity_backend(backend="lexical")
+        assert b.name == "lexical"
+
+    def test_no_api_key_degrades_to_lexical(self):
+        b = make_similarity_backend(backend="embedding", provider="openai", api_key=None)
+        assert b.name == "lexical"
+
+    def test_unsupported_provider_degrades(self):
+        b = make_similarity_backend(backend="embedding", provider="google", api_key="k")
+        assert b.name == "lexical"
+
+    def test_embedding_backend_built_with_key(self, tmp_path):
+        b = make_similarity_backend(
+            backend="embedding", provider="openai", api_key="sk-test",
+            cache_path=str(tmp_path / "e.json"),
+        )
+        assert b.name == "embedding"  # constructed; no network until used
+
+
+class TestOpenAIEmbedder:
+    def test_returns_callable_and_empty_is_noop(self):
+        embed = make_openai_embedder("text-embedding-3-small", "sk-test")
+        assert callable(embed)
+        assert embed([]) == []  # short-circuits before any network call

--- a/tests/continuous/test_skill_stats.py
+++ b/tests/continuous/test_skill_stats.py
@@ -1,0 +1,97 @@
+"""Tests for SkillStats, the store, and credit assignment."""
+
+from __future__ import annotations
+
+from src.continuous.episode import Outcome
+from src.continuous.skill_stats import (
+    SkillStats,
+    SkillStatsStore,
+    assign_credit,
+    assign_credit_batch,
+)
+
+from .conftest import make_episode
+
+
+class TestSkillStats:
+    def test_success_rate(self):
+        s = SkillStats(name="x", episodes_active=4, success_when_active=1)
+        assert s.success_rate == 0.25
+
+    def test_success_rate_zero_episodes(self):
+        assert SkillStats(name="x").success_rate == 0.0
+
+
+class TestSkillStatsStore:
+    def test_get_creates_empty(self, tmp_path):
+        store = SkillStatsStore(tmp_path / "s.json")
+        assert not store.has("x")
+        s = store.get("x")
+        assert s.name == "x" and s.episodes_active == 0
+        assert store.has("x")
+
+    def test_save_load_roundtrip(self, tmp_path):
+        store = SkillStatsStore(tmp_path / "sub" / "s.json")
+        s = store.get("x")
+        s.episodes_active = 3
+        store.upsert(s)
+        store.save()
+        reloaded = SkillStatsStore(tmp_path / "sub" / "s.json")
+        assert reloaded.get("x").episodes_active == 3
+
+    def test_corrupt_file_empty(self, tmp_path):
+        (tmp_path / "s.json").write_text("{bad")
+        assert SkillStatsStore(tmp_path / "s.json").all() == []
+
+    def test_remove(self, tmp_path):
+        store = SkillStatsStore(tmp_path / "s.json")
+        store.get("x")
+        store.remove("x")
+        assert not store.has("x")
+
+
+class TestAssignCredit:
+    def test_sole_skill_gets_full_credit_on_success(self, tmp_path):
+        store = SkillStatsStore(tmp_path / "s.json")
+        ep = make_episode("e", "t", outcome=Outcome.SUCCESS)
+        ep.skills_active = ["solo"]
+        assert assign_credit(store, ep) is True
+        s = store.get("solo")
+        assert s.episodes_active == 1
+        assert s.success_when_active == 1
+        assert s.contribution == 1.0
+
+    def test_credit_shared_among_active_skills(self, tmp_path):
+        store = SkillStatsStore(tmp_path / "s.json")
+        ep = make_episode("e", "t", outcome=Outcome.SUCCESS)
+        ep.skills_active = ["a", "b"]
+        assign_credit(store, ep)
+        assert store.get("a").contribution == 0.5
+        assert store.get("b").contribution == 0.5
+
+    def test_failure_counts_usage_but_no_contribution(self, tmp_path):
+        store = SkillStatsStore(tmp_path / "s.json")
+        ep = make_episode("e", "t", outcome=Outcome.FAILURE)
+        ep.skills_active = ["a"]
+        assign_credit(store, ep)
+        s = store.get("a")
+        assert s.episodes_active == 1
+        assert s.success_when_active == 0
+        assert s.contribution == 0.0
+
+    def test_no_active_skills_skipped(self, tmp_path):
+        store = SkillStatsStore(tmp_path / "s.json")
+        ep = make_episode("e", "t", outcome=Outcome.SUCCESS)  # skills_active empty
+        assert assign_credit(store, ep) is False
+        assert store.all() == []
+
+    def test_batch_counts_and_saves(self, tmp_path):
+        store = SkillStatsStore(tmp_path / "s.json")
+        eps = [make_episode(f"e{i}", "t", outcome=Outcome.SUCCESS) for i in range(3)]
+        for e in eps:
+            e.skills_active = ["a"]
+        eps.append(make_episode("none", "t"))  # no skills → not credited
+        credited = assign_credit_batch(store, eps)
+        assert credited == 3
+        assert store.get("a").episodes_active == 3
+        assert (tmp_path / "s.json").is_file()  # saved


### PR DESCRIPTION
## Continuous Evolution

What: **EvoSkill now learns skills from real agent traces continuously** : instead of only from one-shot benchmark runs. It turns EvoSkill from a one-shot batch optimizer into an always-on learner. It mines the agent's real execution traces (the ATIF trajectory.json every Harbor/Arena run already emits), clusters recurring failures, distills a reusable skill for each, gates it on held-out tasks with a surrogate verifier, and graduates winners into the live  .claude/skills/ library

How: mine trajectories → cluster recurring failures → distill a skill → gate it on held-out tasks (no labels needed) → graduate into .claude/skills/ as a program/* branch.

Why it matters: works without a labeled dataset, learns from real usage, and stays curated (dedup/deprecation) — all safe and revertible.

Adds: src/continuous/ + 6 commands (harvest, candidates, library, graduate, reject, watch). Additive only — no existing behavior changed. 228 tests, ~97% coverage.

## Try it

# From the repo root
`mkdir -p /tmp/evo-demo/.evoskill && cd /tmp/evo-demo`
`printf '[harness]\nname = "claude"\n\n[continuous]\ntrace_sources = ["harbor"]\n' > .evoskill/config.toml
`
### A) No-cost: cluster recurring failures from real trajectories (no model call)
```
evoskill harvest --traces path/to/arena-trajectories --source harbor \
    --dry-run --min-cluster-size 5
```

### B) Real run: distill candidate skills (needs a model key, e.g. ANTHROPIC_API_KEY)
```
evoskill harvest --traces path/to/arena-trajectories --source harbor \
    --min-cluster-size 5 --max-candidates 3
```

```
evoskill candidates                 # list distilled skills
evoskill candidates --show <id>     # view a candidate's SKILL.md
evoskill graduate <id>              # gate → install into .claude/skills/ + program/* branch
evoskill library                    # live skills + usage/credit stats
```

### C) End-to-end in one tick (collect → distill → gate → graduate)
```
evoskill watch --once --mode auto
```
Test: uv run pytest tests/continuous/ -q