### PR TITLE
feat: add vLLM SDK backend for evaluation and self-evolution scripts

### DIFF
--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -48,14 +48,17 @@ class EvalSettings(BaseSettings):
         default=Path("~/officeqa/officeqa.csv").expanduser(),
         description="Path to OfficeQA dataset CSV",
     )
-    sdk: Literal["claude", "opencode", "codex", "goose", "openhands"] = Field(
+    sdk: Literal[
+        "claude", "opencode", "codex", "goose", "openhands"
+    ] = Field(
         default="claude",
-        description="SDK to use: 'claude', 'opencode', 'codex', or 'goose'",
+        description="SDK to use: 'claude', 'opencode', 'codex', 'goose', or 'openhands'",
     )
 
 
 async def main(settings: EvalSettings):
     set_sdk(settings.sdk)
+    print(f"[SDK] {settings.sdk} backend, model: {settings.model}")
 
     # Load dataset
     data = pd.read_csv(settings.dataset_path)

--- a/scripts/run_eval_dabstep.py
+++ b/scripts/run_eval_dabstep.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from src.harness import Agent
 from src.agent_profiles import dabstep_agent_options, make_dabstep_agent_options
+from src.agent_profiles import set_sdk, set_vllm_config
 from src.evaluation.eval_full import evaluate_full, load_results
 from src.evaluation.dabstep_scorer import question_scorer
 from src.schemas import AgentResponse
@@ -80,7 +81,45 @@ async def main():
         default="claude-opus-4-5-20251101",
         help="Model for agent (default: claude-opus-4-5-20251101)",
     )
+    parser.add_argument(
+        "--sdk",
+        type=str,
+        default="claude",
+        choices=["claude", "opencode", "vllm"],
+        help="SDK backend to use: claude (default), opencode, or vllm",
+    )
+    parser.add_argument(
+        "--vllm-base-url",
+        type=str,
+        default="http://localhost:8000/v1",
+        help="vLLM server base URL (used when --sdk vllm, default: http://localhost:8000/v1)",
+    )
+    parser.add_argument(
+        "--vllm-max-tokens",
+        type=int,
+        default=8192,
+        help="Max tokens for vLLM generation (default: 8192)",
+    )
+    parser.add_argument(
+        "--vllm-context-length",
+        type=int,
+        default=131072,
+        help="vLLM model context window size (default: 131072 for 128K models like Qwen2.5-72B)",
+    )
     args = parser.parse_args()
+
+    # Configure SDK backend
+    set_sdk(args.sdk)
+    if args.sdk == "vllm":
+        set_vllm_config(
+            base_url=args.vllm_base_url,
+            model_name=args.model,
+            max_tokens=args.vllm_max_tokens,
+            context_length=args.vllm_context_length,
+        )
+        print(f"[SDK] vLLM backend: {args.vllm_base_url}, model: {args.model}, context: {args.vllm_context_length}, max_tokens: {args.vllm_max_tokens}")
+    else:
+        print(f"[SDK] {args.sdk} backend, model: {args.model}")
 
     # Load dataset
     data = pd.read_csv(args.dataset)
@@ -97,9 +136,14 @@ async def main():
 
     # Auto-discover context files from data-dir
     data_dir = Path(args.data_dir).resolve()
-    context_file_names = sorted(f.name for f in data_dir.iterdir() if f.is_file())
-    context_files_text = "\n".join(f"- {data_dir / name}" for name in context_file_names)
-    print(f"Context files ({len(context_file_names)}): {', '.join(context_file_names)}")
+    if data_dir.exists():
+        context_file_names = sorted(f.name for f in data_dir.iterdir() if f.is_file())
+        context_files_text = "\n".join(f"- {data_dir / name}" for name in context_file_names)
+        print(f"Context files ({len(context_file_names)}): {', '.join(context_file_names)}")
+    else:
+        context_file_names = []
+        context_files_text = "(no context files available)"
+        print(f"[WARNING] data-dir not found: {data_dir}. Context files will be unavailable.")
 
     # Prepare items: (task_id, formatted_prompt, answer)
     items = [

--- a/scripts/run_eval_livecodebench.py
+++ b/scripts/run_eval_livecodebench.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pandas as pd
 
 from src.harness import Agent, set_sdk
-from src.agent_profiles import make_livecodebench_agent_options
+from src.agent_profiles import make_livecodebench_agent_options, set_vllm_config
 from src.evaluation.eval_full import evaluate_full, load_results
 from src.evaluation.livecodebench import (
     score_livecodebench,
@@ -77,14 +77,42 @@ async def main():
     parser.add_argument(
         "--sdk",
         type=str,
-        choices=["claude", "opencode"],
+        choices=["claude", "opencode", "vllm"],
         default="claude",
-        help="SDK to use: 'claude' or 'opencode' (default: claude)",
+        help="SDK to use: 'claude', 'opencode', or 'vllm' (default: claude)",
+    )
+    parser.add_argument(
+        "--vllm-base-url",
+        type=str,
+        default="http://localhost:8000/v1",
+        help="vLLM server base URL (used when --sdk vllm, default: http://localhost:8000/v1)",
+    )
+    parser.add_argument(
+        "--vllm-max-tokens",
+        type=int,
+        default=8192,
+        help="Max tokens for vLLM generation (default: 8192)",
+    )
+    parser.add_argument(
+        "--vllm-context-length",
+        type=int,
+        default=131072,
+        help="vLLM model context window size (default: 131072 for 128K models like Qwen2.5-72B)",
     )
     args = parser.parse_args()
 
     # Set SDK
     set_sdk(args.sdk)
+    if args.sdk == "vllm":
+        set_vllm_config(
+            base_url=args.vllm_base_url,
+            model_name=args.model,
+            max_tokens=args.vllm_max_tokens,
+            context_length=args.vllm_context_length,
+        )
+        print(f"[SDK] vLLM backend: {args.vllm_base_url}, model: {args.model}, context: {args.vllm_context_length}, max_tokens: {args.vllm_max_tokens}")
+    else:
+        print(f"[SDK] {args.sdk} backend, model: {args.model}")
 
     # Ensure dataset is downloaded
     if args.dataset is None:

--- a/scripts/run_eval_sealqa.py
+++ b/scripts/run_eval_sealqa.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from src.harness import Agent
 from src.agent_profiles import sealqa_agent_options, make_sealqa_agent_options
+from src.agent_profiles import set_sdk, set_vllm_config
 from src.evaluation.eval_full import evaluate_full, load_results
 from src.evaluation.sealqa_scorer import score_sealqa
 from src.schemas import AgentResponse
@@ -62,7 +63,45 @@ async def main():
         default="claude-opus-4-5-20251101",
         help="Model for agent (default: claude-opus-4-5-20251101)",
     )
+    parser.add_argument(
+        "--sdk",
+        type=str,
+        default="claude",
+        choices=["claude", "opencode", "vllm"],
+        help="SDK backend to use: claude (default), opencode, or vllm",
+    )
+    parser.add_argument(
+        "--vllm-base-url",
+        type=str,
+        default="http://localhost:8000/v1",
+        help="vLLM server base URL (used when --sdk vllm, default: http://localhost:8000/v1)",
+    )
+    parser.add_argument(
+        "--vllm-max-tokens",
+        type=int,
+        default=8192,
+        help="Max tokens for vLLM generation (default: 8192)",
+    )
+    parser.add_argument(
+        "--vllm-context-length",
+        type=int,
+        default=131072,
+        help="vLLM model context window size (default: 131072 for 128K models like Qwen2.5-72B)",
+    )
     args = parser.parse_args()
+
+    # Configure SDK backend
+    set_sdk(args.sdk)
+    if args.sdk == "vllm":
+        set_vllm_config(
+            base_url=args.vllm_base_url,
+            model_name=args.model,
+            max_tokens=args.vllm_max_tokens,
+            context_length=args.vllm_context_length,
+        )
+        print(f"[SDK] vLLM backend: {args.vllm_base_url}, model: {args.model}, context: {args.vllm_context_length}, max_tokens: {args.vllm_max_tokens}")
+    else:
+        print(f"[SDK] {args.sdk} backend, model: {args.model}")
 
     # Load dataset
     data = pd.read_csv(args.dataset)

--- a/scripts/run_loop.py
+++ b/scripts/run_loop.py
@@ -21,6 +21,7 @@ from src.agent_profiles import (
     skill_generator_options,
     prompt_generator_options,
     set_sdk,
+    set_vllm_config,
 )
 from src.agent_profiles.skill_generator import get_project_root
 from src.registry import ProgramManager
@@ -84,9 +85,23 @@ class LoopSettings(BaseSettings):
     model: Optional[str] = Field(
         default=None, description="Model for base agent (opus, sonnet, haiku)"
     )
-    sdk: Literal["claude", "opencode", "codex", "goose", "openhands"] = Field(
+    sdk: Literal[
+        "claude", "opencode", "codex", "goose", "openhands", "vllm"
+    ] = Field(
         default="claude",
-        description="SDK to use: 'claude', 'opencode', 'codex', or 'goose'",
+        description="SDK to use: 'claude', 'opencode', 'codex', 'goose', 'openhands', or 'vllm'",
+    )
+    vllm_base_url: str = Field(
+        default="http://localhost:8000/v1",
+        description="vLLM server base URL (only used when sdk='vllm')",
+    )
+    vllm_max_tokens: int = Field(
+        default=8192,
+        description="Max tokens for vLLM generation (only used when sdk='vllm')",
+    )
+    vllm_context_length: int = Field(
+        default=131072,
+        description="vLLM model context window size (default: 131072 for 128K models like Qwen2.5-72B)",
     )
 
 
@@ -138,6 +153,13 @@ def stratified_split(
 async def main(settings: LoopSettings):
     # Set SDK based on CLI argument
     set_sdk(settings.sdk)
+    if settings.sdk == "vllm":
+        set_vllm_config(
+            base_url=settings.vllm_base_url,
+            model_name=settings.model,
+            max_tokens=settings.vllm_max_tokens,
+            context_length=settings.vllm_context_length,
+        )
 
     data = pd.read_csv(settings.dataset)
 


### PR DESCRIPTION
Add a `vllm` SDK backend across all run/eval scripts so the project can target a self-hosted vLLM OpenAI-compatible server for local inference with open-weight models (Qwen, Gemma, etc.).

Changes
- scripts/run_loop.py, run_eval_dabstep.py, run_eval_sealqa.py, run_eval_livecodebench.py: add `--sdk vllm` choice with `--vllm-base-url`, `--vllm-max-tokens`, `--vllm-context-length` flags wired through `set_vllm_config`.
- serve_vllm.sh: helper script to launch a vLLM OpenAI server.
