### PR TITLE
fix(opencode): stop re-fetching messages after chat POST (opencode #25430)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,9 +29,9 @@ yellow(){ printf "\033[33m%s\033[0m" "$1"; }
 red()   { printf "\033[31m%s\033[0m" "$1"; }
 dim()   { printf "\033[2m%s\033[0m" "$1"; }
 
-info()  { printf "  $(green '✓') %s\n" "$1"; }
-warn()  { printf "  $(yellow '!') %s\n" "$1"; }
-fail()  { printf "  $(red '✗') %s\n" "$1"; exit 1; }
+info()  { printf "  $(green '✓') %s\n" "$1" >&2; }
+warn()  { printf "  $(yellow '!') %s\n" "$1" >&2; }
+fail()  { printf "  $(red '✗') %s\n" "$1" >&2; exit 1; }
 
 usage() {
     cat <<'EOF'
@@ -80,7 +80,7 @@ ensure_repo() {
     fi
 
     local target="${INSTALL_DIR:-$(pwd)/EvoSkill}"
-    printf "\n  %s\n\n" "$(bold 'Cloning EvoSkill repository...')"
+    printf "\n  %s\n\n" "$(bold 'Cloning EvoSkill repository...')" >&2
 
     if [[ -d "$target/.git" ]]; then
         info "Repository already exists at $target"
@@ -115,7 +115,7 @@ find_python_312() {
 }
 
 try_install_python_312() {
-    printf "\n  %s\n" "$(bold 'Attempting to install Python 3.12...')"
+    printf "\n  %s\n" "$(bold 'Attempting to install Python 3.12...')" >&2
 
     if [[ "$(uname -s)" == "Darwin" ]] && command -v brew &>/dev/null; then
         if brew install python@3.12; then

--- a/src/harness/opencode/executor.py
+++ b/src/harness/opencode/executor.py
@@ -164,6 +164,23 @@ def _ensure_server(options: dict[str, Any]) -> str:
 
 # ── query execution ──────────────────────────────────────────────────
 
+def _as_message(chat_info: Any) -> dict[str, Any]:
+    """Coerce an opencode ``POST /session/{id}/message`` response into the
+    ``{"info": {...}, "parts": [...]}`` shape that :func:`parse_response` expects.
+
+    The server returns the full assistant message as ``{"info": ..., "parts": ...}``;
+    a bare info dict (optionally carrying a ``parts`` key) is also tolerated so the
+    parser keeps working if the response envelope changes across opencode versions.
+    """
+    if not isinstance(chat_info, dict):
+        return {"info": {}, "parts": []}
+    if isinstance(chat_info.get("info"), dict):
+        return {"info": chat_info["info"], "parts": chat_info.get("parts") or []}
+    parts = chat_info.get("parts") or []
+    info = {k: v for k, v in chat_info.items() if k != "parts"}
+    return {"info": info, "parts": parts}
+
+
 async def execute_query(options: dict[str, Any], query: str) -> list[Any]:
     if not isinstance(options, dict):
         raise TypeError(f"OpenCode executor requires dict options, got {type(options)}")
@@ -198,10 +215,16 @@ async def execute_query(options: dict[str, Any], query: str) -> list[Any]:
         r.raise_for_status()
         chat_info = r.json()
 
-        # 3. fetch full messages (with parts + structured output)
-        r = await client.get(f"/session/{session_id}/message")
-        r.raise_for_status()
-        messages = r.json()
+        # 3. derive the assistant message from the POST response above.
+        # We deliberately do NOT re-fetch via GET /session/{id}/message: on
+        # opencode 1.16.x–1.17.4 that GET returns 400 whenever the session used a
+        # json_schema format, because the server writes its own retryCount
+        # bookkeeping into the message ``format`` field and then rejects it on
+        # serialization (opencode #25430). The paid model call has already
+        # succeeded here, so the re-fetch only raises a spurious HTTPStatusError
+        # and forces a full (billable) retry. Each query runs in a fresh
+        # single-turn session, so chat_info is the complete reply.
+        messages = [_as_message(chat_info)]
 
     return [{"session_id": session_id, "chat_info": chat_info, "messages": messages}]
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -552,7 +552,9 @@ def _make_opencode_payload(info=None, parts=None, session_id="sess-456", cost=0.
 
     return {
         "session_id": session_id,
-        "chat_info": assistant_info,
+        # opencode's POST /session/{id}/message returns the full assistant
+        # message ({info, parts}); mirror that real shape here.
+        "chat_info": {"info": assistant_info, "parts": raw_parts},
         "messages": [{"info": assistant_info, "parts": raw_parts}],
     }
 
@@ -564,6 +566,96 @@ def _make_opencode_get_options(provider_id="anthropic", model_id="claude-sonnet-
         "model": f"{provider_id}/{model_id}",
         "tools": tools or {"read": True, "bash": True},
     }
+
+
+class TestOpencodeExecuteQuery:
+    """execute_query must not re-fetch messages after the chat POST.
+
+    Regression for opencode #25430: GET /session/{id}/message 400s on
+    json_schema sessions, which previously crashed every structured-output
+    query after the (already billed) model call succeeded.
+    """
+
+    def test_does_not_refetch_messages_after_chat_post(self, monkeypatch):
+        from src.harness.opencode import executor as oc
+
+        # opencode's POST /session/{id}/message returns the full assistant message.
+        assistant_msg = {
+            "info": {
+                "role": "assistant",
+                "structured": {"final_answer": "4", "reasoning": "math"},
+                "cost": 0.01,
+                "tokens": {"input": 5},
+            },
+            "parts": [{"type": "text", "text": "the answer is 4"}],
+        }
+
+        class _Resp:
+            def __init__(self, data):
+                self._data = data
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return self._data
+
+        class _FakeClient:
+            def __init__(self, *args, **kwargs):
+                self.gets: list[str] = []
+                self.posts: list[str] = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def post(self, url, json=None):
+                self.posts.append(url)
+                if url == "/session":
+                    return _Resp({"id": "sess-1"})
+                if url.endswith("/message"):
+                    return _Resp(assistant_msg)
+                raise AssertionError(f"unexpected POST {url}")
+
+            async def get(self, url):
+                self.gets.append(url)
+                raise AssertionError(
+                    f"execute_query must not GET {url} — it 400s on json_schema "
+                    "sessions (opencode #25430)"
+                )
+
+        clients: list[_FakeClient] = []
+
+        def _factory(*args, **kwargs):
+            client = _FakeClient(*args, **kwargs)
+            clients.append(client)
+            return client
+
+        monkeypatch.setattr(oc, "_ensure_server", lambda options: "http://127.0.0.1:0")
+        monkeypatch.setattr(oc, "ensure_provider_api_key", lambda provider: "key")
+        monkeypatch.setattr(oc.httpx, "AsyncClient", _factory)
+
+        result = asyncio.run(
+            oc.execute_query(
+                {
+                    "provider_id": "fireworks-ai",
+                    "model_id": "minimax-m2p7",
+                    "format": {"type": "json_schema"},
+                },
+                "what is 2+2?",
+            )
+        )
+
+        # No message re-fetch happened (the GET would have raised).
+        assert clients and clients[0].gets == []
+        # The POST response alone is enough to parse structured output.
+        fields = opencode_parse(result, AgentResponse, _make_opencode_get_options())
+        assert fields["output"] is not None
+        assert fields["output"].final_answer == "4"
+        assert fields["parse_error"] is None
+        assert fields["total_cost_usd"] == 0.01
 
 
 class TestOpencodeParseResponse:


### PR DESCRIPTION
The opencode harness re-fetched GET /session/{id}/message after the chat POST. On opencode 1.16.x-1.17.4 that GET 400s whenever the session used a json_schema format: the server stores its own retryCount inside the message `format` field, then rejects it on serialization. The model call had already succeeded, so every structured-output query raised HTTPStatusError, retried (extra spend), and ultimately failed every attempt.

The POST response already contains the full assistant message, so the GET is removed and messages are derived from it via a shape-tolerant helper (_as_message). Adds a regression test asserting no re-fetch is issued and that the POST response alone parses to structured output, and corrects the opencode test fixture to mirror the real {info, parts} POST shape.

Also fixes install.sh: status banners and info/warn/fail wrote to stdout inside functions whose stdout is captured via $(...), so `curl ... | bash` broke when the "Cloning EvoSkill repository..." banner contaminated REPO_ROOT (and the same class of bug affected the --pip path). Status output now goes to stderr.

Note: the missing provider_auth entry for `fireworks-ai` (bug 1 in the report) was already resolved in v1.3.0.

Reported-by: Leonwenhao
Closes #48